### PR TITLE
fix(landing): add CJK fallback for mono text

### DIFF
--- a/docs/landing/src/style.css
+++ b/docs/landing/src/style.css
@@ -39,7 +39,9 @@
   --font-display:
     'Inter', 'Noto Sans SC', -apple-system, BlinkMacSystemFont, 'SF Pro Display', 'SF Pro Text',
     system-ui, 'Hiragino Sans GB', 'Microsoft YaHei', sans-serif;
-  --font-mono: 'JetBrains Mono', 'SF Mono', ui-monospace, monospace;
+  --font-mono:
+    'JetBrains Mono', 'SF Mono', 'Noto Sans SC', 'PingFang SC', 'Hiragino Sans GB',
+    'Microsoft YaHei', ui-monospace, monospace;
 }
 
 .dark {


### PR DESCRIPTION
## 改动内容

修改网站的Mono字符回退问题

## 验证

是

## 截图或录屏

修复前：
<img width="213" height="72" alt="image" src="https://github.com/user-attachments/assets/c4d325aa-0665-4659-b369-3232f6742708" />

## CLA

- [ x ] I have read the CLA Document and I hereby sign the CLA.

如果不勾选上面的声明，也可以由 PR 作者在评论区发送：

> I have read the CLA Document and I hereby sign the CLA.

## Summary by Sourcery

Enhancements:
- Add CJK-compatible fallback fonts to the monospace CSS variable used on the landing page.