### PR TITLE
doc(README)：更新 README 文件，反映项目代码行数和源文件数量的增加，并添加自动化测试与构建部分的说明。

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 在学校的日子挺无聊的，平时又总会冒出很多想问 AI 的问题。当时我嫌 App Store 上的 AI 应用要么贵得离谱，要么功能太残废（尤其是手表端），索性就自己动手搓了一个。
 
-从最初那个只有 1,800 行代码、API Key 还要硬编码的简陋版本，到现在 **641 个 Swift 源文件、226,381 行 Swift 代码**（仅计算项目内 Swift，不把 llama.cpp 子模块和 VitePress 文档站依赖算进来）的工程，它确实已经长大了不少。虽然名字叫 "ETOS LLM Studio" 听着有点唬人，但它本质上还是我拿来探索大模型应用边界的试验场。
+从最初那个只有 1,800 行代码、API Key 还要硬编码的简陋版本，到现在 **758 个 Swift 源文件、284,139 行 Swift 代码**（仅计算项目内 Swift，不把 llama.cpp 子模块和 VitePress 文档站依赖算进来）的工程，它确实已经长大了不少。虽然名字叫 "ETOS LLM Studio" 听着有点唬人，但它本质上还是我拿来探索大模型应用边界的试验场。
 
 现在它已经不只是一个手表端 App 了：我把 iOS 端也一点点补成了完整版本，方便在手机上管理云端模型、本地 GGUF 权重、工具、记忆、世界书和每日脉冲；两端数据还能通过内置同步引擎自动互通。
 
@@ -146,7 +146,7 @@
 项目采用双层结构：平台无关的 ETOSCore 框架 + 各平台独立的视图层。最近一轮重构引入了 `Config/AppConfigStore` 配置中心，全量替代 `@AppStorage`，并新增 `LocalLLM` / `LocalLLMBridge` 把本机 GGUF 推理接入现有聊天生命周期；同时把 MCP、同步导入、局域网调试和会话标签继续拆成独立模块。当前最大 Swift 文件约 1,540 行（`Sync/WatchSyncManager.swift`），本地模型管理页、同步引擎和工具中心仍是后续继续拆分的重型模块。
 
 ```
-ETOSCore/ETOSCore/                         ← 平台无关业务逻辑（293 个 Swift 源文件）
+ETOSCore/ETOSCore/                         ← 平台无关业务逻辑（349 个 Swift 源文件）
 ├── AppTool/                            ← 本地工具、自定义 JS 工具、ask_user_input、SQLite 与沙盒文件工具
 ├── Attachments/                        ← 文件附件文本抽取
 ├── Chat/                               ← 聊天模型、消息版本、导出、渲染状态
@@ -166,6 +166,7 @@ ETOSCore/ETOSCore/                         ← 平台无关业务逻辑（293 �
 ├── Parsing/                            ← 请求头与参数表达式解析
 ├── Persistence/                        ← GRDB 主库/辅助库、迁移、启动备份、媒体与文件存储
 ├── Providers/                          ← Provider 模型、代理配置与 OpenAI / Anthropic / Gemini 适配器
+├── Roleplay/                           ← 角色扮演人设、聊天提示词模板与预置角色库
 ├── Security/                           ← 应用锁状态机、PBKDF2 主密码与数据库加密管理
 ├── Shortcuts/                          ← Siri Shortcuts、URL Router、导入与执行中继
 ├── Skills/                             ← Agent Skills 技能包导入、解析、GitHub 拉取、资源读取与策略
@@ -178,9 +179,9 @@ ETOSCore/ETOSCore/                         ← 平台无关业务逻辑（293 �
 ├── UsageAnalytics/                     ← 用量事件、统计仪表盘、按小时趋势与模型 Token 占比
 └── Worldbook/                          ← 世界书模型、导入导出、SQLite 存储与触发引擎
 
-ETOS LLM Studio/ETOS LLM Studio iOS App/    ← iOS 视图层（133 个 Swift 源文件）
-ETOS LLM Studio/ETOS LLM Studio Watch App/  ← watchOS 视图层（111 个 Swift 源文件）
-ETOSCore/ETOSCoreTests/                         ← ETOSCore 层测试（102 个 Swift 源文件）
+ETOS LLM Studio/ETOS LLM Studio iOS App/    ← iOS 视图层（155 个 Swift 源文件）
+ETOS LLM Studio/ETOS LLM Studio Watch App/  ← watchOS 视图层（131 个 Swift 源文件）
+ETOSCore/ETOSCoreTests/                         ← ETOSCore 层测试（116 个 Swift 源文件）
 ```
 
 云端模型数据流：`View → ChatViewModel → ChatService.shared → Provider Adapter → LLM API`。本地模型数据流：`View → ChatViewModel → ChatService.shared → LocalLLMEngine → LocalLLMBridge → libetos-llama.a / llama.cpp`。会话、工具、记忆、世界书、用量统计与同步数据经由 ETOSCore 层服务和 GRDB/SQLite 存储统一治理。
@@ -223,6 +224,33 @@ ETOSCore/ETOSCoreTests/                         ← ETOSCore 层测试（102 个
 
 ---
 
+## 🧪 自动化测试与构建
+
+如需在命令行执行一键编译或单元测试，请统一使用以下标准 `xcodebuild` 命令（已配置隔离环境变量，避免本机环境污染导致的 watchOS 链接失败）：
+
+* **构建 iOS App（自动包含 watch App）**：
+  ```bash
+  env -u SDKROOT -u LIBRARY_PATH -u CPATH -u C_INCLUDE_PATH -u CPLUS_INCLUDE_PATH -u OBJC_INCLUDE_PATH xcodebuild -workspace 'ETOS LLM Studio.xcworkspace' -scheme 'ETOS LLM Studio App' -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.5' build
+  ```
+* **单独验证 watchOS App 构建**：
+  ```bash
+  env -u SDKROOT -u LIBRARY_PATH -u CPATH -u C_INCLUDE_PATH -u CPLUS_INCLUDE_PATH -u OBJC_INCLUDE_PATH xcodebuild -workspace 'ETOS LLM Studio.xcworkspace' -scheme 'ETOS LLM Studio Watch App' -destination 'generic/platform=watchOS Simulator' build
+  ```
+* **运行 ETOSCore 核心框架单元测试**（116 个测试源文件，41,055 行测试代码）：
+  ```bash
+  env -u SDKROOT -u LIBRARY_PATH -u CPATH -u C_INCLUDE_PATH -u CPLUS_INCLUDE_PATH -u OBJC_INCLUDE_PATH xcodebuild -workspace 'ETOS LLM Studio.xcworkspace' -scheme 'ETOSCore' -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.5' -parallel-testing-enabled NO test
+  ```
+* **运行 iOS App 单元与 UI 测试**：
+  ```bash
+  env -u SDKROOT -u LIBRARY_PATH -u CPATH -u C_INCLUDE_PATH -u CPLUS_INCLUDE_PATH -u OBJC_INCLUDE_PATH xcodebuild -workspace 'ETOS LLM Studio.xcworkspace' -scheme 'ETOS LLM Studio App' -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.5' -parallel-testing-enabled NO test
+  ```
+* **运行 watchOS App 单元与 UI 测试**：
+  ```bash
+  env -u SDKROOT -u LIBRARY_PATH -u CPATH -u C_INCLUDE_PATH -u CPLUS_INCLUDE_PATH -u OBJC_INCLUDE_PATH xcodebuild -workspace 'ETOS LLM Studio.xcworkspace' -scheme 'ETOS LLM Studio Watch App' -destination 'platform=watchOS Simulator,name=Apple Watch Series 11 (42mm),OS=26.5' -parallel-testing-enabled NO test
+  ```
+
+---
+
 ## 🤝 贡献与 CLA
 
 欢迎提 Issue、PR、文档修订和翻译补全。开始前请阅读 [贡献指南](CONTRIBUTING.md)。
@@ -241,4 +269,4 @@ ETOSCore/ETOSCoreTests/                         ← ETOSCore 层测试（102 个
 
 ---
 
-本次 README 修订于 2026 年 6 月 27 日（基于 `cb7bf431` 之后的提交）。项目更新频率比较高，如果你发现 README 跟不上代码，欢迎直接翻提交记录。
+本次 README 修订于 2026 年 7 月 25 日。项目更新频率比较高，如果你发现 README 跟不上代码，欢迎直接翻提交记录。

--- a/docs/readme/README_EN.md
+++ b/docs/readme/README_EN.md
@@ -23,7 +23,7 @@
 
 School life can be pretty boring, and I always seem to have a lot of things I want to ask AI. At the time, most AI apps on the App Store were either absurdly expensive or too limited to be useful—especially on Apple Watch—so I ended up building one myself.
 
-What started as a rough little app with only 1,800 lines of code and hardcoded API keys has grown into a project with **641 Swift source files and 226,381 lines of Swift code** (project Swift only; the llama.cpp submodule and VitePress doc-site dependencies are not included). “ETOS LLM Studio” may sound a bit over the top, but in reality it is still my playground for exploring the boundaries of LLM applications.
+What started as a rough little app with only 1,800 lines of code and hardcoded API keys has grown into a project with **758 Swift source files and 284,139 lines of Swift code** (project Swift only; the llama.cpp submodule and VitePress doc-site dependencies are not included). “ETOS LLM Studio” may sound a bit over the top, but in reality it is still my playground for exploring the boundaries of LLM applications.
 
 It is no longer just a Watch app either. I have gradually expanded the iOS side into a complete experience for managing cloud models, local GGUF weights, tools, memory, worldbooks, and Daily Pulse, and the two platforms stay in sync through the built-in sync engine.
 
@@ -146,7 +146,7 @@ Technology should be shared. I do not want a small price barrier to block someon
 The project uses a two-layer structure: a platform-independent ETOSCore framework plus platform-specific view layers. The latest round of refactoring introduced the `Config/AppConfigStore` configuration hub, fully replaced `@AppStorage`, and added `LocalLLM` / `LocalLLMBridge` to route on-device GGUF inference into the existing chat lifecycle. MCP, sync/import, LAN debugging, and session tags have also been split into dedicated modules. The largest single Swift file is about 1,540 lines (`Sync/WatchSyncManager.swift`); local model management, the sync engine, and Tool Center remain heavier modules to keep trimming over time.
 
 ```
-ETOSCore/ETOSCore/                         ← Platform-agnostic business logic (293 Swift source files)
+ETOSCore/ETOSCore/                         ← Platform-agnostic business logic (349 Swift source files)
 ├── AppTool/                            ← Local tools, custom JS tools, ask_user_input, SQLite and sandbox file tools
 ├── Attachments/                        ← File attachment text extraction
 ├── Chat/                               ← Chat models, message versions, export, render state
@@ -166,6 +166,7 @@ ETOSCore/ETOSCore/                         ← Platform-agnostic business logic 
 ├── Parsing/                            ← Request-header and parameter-expression parsers
 ├── Persistence/                        ← GRDB main/auxiliary databases, migrations, startup backup, media and file storage
 ├── Providers/                          ← Provider models, proxy configuration, and OpenAI / Anthropic / Gemini adapters
+├── Roleplay/                           ← Roleplay personas, chat prompt templates, and preset character library
 ├── Security/                           ← App lock state machine, PBKDF2 master password, and database encryption manager
 ├── Shortcuts/                          ← Siri Shortcuts, URL router, import and execution relays
 ├── Skills/                             ← Agent Skills bundle import, parsing, GitHub fetch, resource reading, and policies
@@ -178,9 +179,9 @@ ETOSCore/ETOSCore/                         ← Platform-agnostic business logic 
 ├── UsageAnalytics/                     ← Usage events, dashboards, per-hour trends, and per-model token share
 └── Worldbook/                          ← Worldbook models, import/export, SQLite storage, and trigger engine
 
-ETOS LLM Studio/ETOS LLM Studio iOS App/    ← iOS view layer (133 Swift source files)
-ETOS LLM Studio/ETOS LLM Studio Watch App/  ← watchOS view layer (111 Swift source files)
-ETOSCore/ETOSCoreTests/                         ← ETOSCore-layer tests (102 Swift source files)
+ETOS LLM Studio/ETOS LLM Studio iOS App/    ← iOS view layer (155 Swift source files)
+ETOS LLM Studio/ETOS LLM Studio Watch App/  ← watchOS view layer (131 Swift source files)
+ETOSCore/ETOSCoreTests/                         ← ETOSCore-layer tests (116 Swift source files)
 ```
 
 Cloud-model data flow: `View → ChatViewModel → ChatService.shared → Provider Adapter → LLM API`. Local-model data flow: `View → ChatViewModel → ChatService.shared → LocalLLMEngine → LocalLLMBridge → libetos-llama.a / llama.cpp`. Sessions, tools, memory, worldbooks, usage analytics, and sync data are all governed through ETOSCore-layer services and GRDB / SQLite storage.
@@ -223,6 +224,33 @@ If you want to build it yourself:
 
 ---
 
+## 🧪 Automated Testing and Build
+
+To build or run tests from the command line, use the standard `xcodebuild` commands below (with environment variables cleared to prevent build failures):
+
+* **Build iOS App (includes embedded watch App)**:
+  ```bash
+  env -u SDKROOT -u LIBRARY_PATH -u CPATH -u C_INCLUDE_PATH -u CPLUS_INCLUDE_PATH -u OBJC_INCLUDE_PATH xcodebuild -workspace 'ETOS LLM Studio.xcworkspace' -scheme 'ETOS LLM Studio App' -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.5' build
+  ```
+* **Verify watchOS App Build**:
+  ```bash
+  env -u SDKROOT -u LIBRARY_PATH -u CPATH -u C_INCLUDE_PATH -u CPLUS_INCLUDE_PATH -u OBJC_INCLUDE_PATH xcodebuild -workspace 'ETOS LLM Studio.xcworkspace' -scheme 'ETOS LLM Studio Watch App' -destination 'generic/platform=watchOS Simulator' build
+  ```
+* **Run ETOSCore Framework Tests** (116 test files, 41,055 lines of test code):
+  ```bash
+  env -u SDKROOT -u LIBRARY_PATH -u CPATH -u C_INCLUDE_PATH -u CPLUS_INCLUDE_PATH -u OBJC_INCLUDE_PATH xcodebuild -workspace 'ETOS LLM Studio.xcworkspace' -scheme 'ETOSCore' -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.5' -parallel-testing-enabled NO test
+  ```
+* **Run iOS App Unit & UI Tests**:
+  ```bash
+  env -u SDKROOT -u LIBRARY_PATH -u CPATH -u C_INCLUDE_PATH -u CPLUS_INCLUDE_PATH -u OBJC_INCLUDE_PATH xcodebuild -workspace 'ETOS LLM Studio.xcworkspace' -scheme 'ETOS LLM Studio App' -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.5' -parallel-testing-enabled NO test
+  ```
+* **Run watchOS App Unit & UI Tests**:
+  ```bash
+  env -u SDKROOT -u LIBRARY_PATH -u CPATH -u C_INCLUDE_PATH -u CPLUS_INCLUDE_PATH -u OBJC_INCLUDE_PATH xcodebuild -workspace 'ETOS LLM Studio.xcworkspace' -scheme 'ETOS LLM Studio Watch App' -destination 'platform=watchOS Simulator,name=Apple Watch Series 11 (42mm),OS=26.5' -parallel-testing-enabled NO test
+  ```
+
+---
+
 ## 📬 Contact
 
 *   **Developer**: Eric Terminal
@@ -231,4 +259,4 @@ If you want to build it yourself:
 
 ---
 
-This README was last revised on June 9, 2026 (based on commits after `cb7bf431`). The project moves quickly, so if the README falls behind the code, the commit history is the best source of truth.
+This README was last revised on July 25, 2026. The project moves quickly, so if the README falls behind the code, the commit history is the best source of truth.

--- a/docs/readme/README_JA.md
+++ b/docs/readme/README_JA.md
@@ -23,7 +23,7 @@
 
 学校生活はけっこう退屈で、普段から AI に聞きたいことが次々に出てきます。当時 App Store にある AI アプリは、値段が高すぎるか、機能が物足りなすぎるかのどちらかで、とくに Watch 側はなおさらでした。なので、いっそ自分で作ることにしました。
 
-最初は 1,800 行しかなく、API Key もハードコーディングしていた雑な試作でしたが、今では **641 個の Swift ソースファイルと 226,381 行の Swift コード**（プロジェクト内 Swift のみ。llama.cpp サブモジュールと VitePress ドキュメントサイトの依存は含みません）を持つプロジェクトにまで育ちました。「ETOS LLM Studio」という名前は少し大げさかもしれませんが、本質的には LLM アプリの境界を探るための私の実験場です。
+最初は 1,800 行しかなく、API Key もハードコーディングしていた雑な試作でしたが、今では **758 個の Swift ソースファイルと 284,139 行の Swift コード**（プロジェクト内 Swift のみ。llama.cpp サブモジュールと VitePress ドキュメントサイトの依存は含みません）を持つプロジェクトにまで育ちました。「ETOS LLM Studio」という名前は少し大げさかもしれませんが、本質的には LLM アプリの境界を探るための私の実験場です。
 
 いまでは単なる Watch アプリではなく、iOS 側もクラウドモデル、ローカル GGUF ウェイト、ツール、記憶、Worldbook、Daily Pulse を管理しやすい形へ少しずつ育てています。さらに、両プラットフォームは内蔵の同期エンジンでデータを共有できます。
 
@@ -146,7 +146,7 @@
 このプロジェクトは、プラットフォーム非依存の ETOSCore フレームワークと、各プラットフォーム専用のビュー層からなる二層構造です。最新のリファクタで `Config/AppConfigStore` 設定ハブを導入して `@AppStorage` を全面的に置き換え、さらに `LocalLLM` / `LocalLLMBridge` により端末上の GGUF 推論を既存のチャットライフサイクルへ接続しました。MCP、同期/インポート、LAN デバッグ、会話タグも独立モジュールとして整理しています。現在最大の Swift ファイルは約 1,540 行（`Sync/WatchSyncManager.swift`）で、ローカルモデル管理、同期エンジン、ツールセンターは今後も少しずつ軽くしていく重めのモジュールです。
 
 ```
-ETOSCore/ETOSCore/                         ← プラットフォーム非依存の業務ロジック（293 個の Swift ソースファイル）
+ETOSCore/ETOSCore/                         ← プラットフォーム非依存の業務ロジック（349 個の Swift ソースファイル）
 ├── AppTool/                            ← ローカルツール、カスタム JS ツール、ask_user_input、SQLite とサンドボックスファイル系ツール
 ├── Attachments/                        ← ファイル添付のテキスト抽出
 ├── Chat/                               ← チャットモデル、メッセージバージョン、エクスポート、描画状態
@@ -166,6 +166,7 @@ ETOSCore/ETOSCore/                         ← プラットフォーム非依存
 ├── Parsing/                            ← リクエストヘッダーとパラメータ式のパーサ
 ├── Persistence/                        ← GRDB のメイン／補助 DB、マイグレーション、起動時バックアップ、メディアとファイル保存
 ├── Providers/                          ← Provider モデル、プロキシ設定、OpenAI / Anthropic / Gemini アダプタ
+├── Roleplay/                           ← ロールプレイペルソナ、チャットプロンプトテンプレート、プリセットキャラクターライブラリ
 ├── Security/                           ← アプリロックの状態機械、PBKDF2 マスターパスワード、データベース暗号化管理
 ├── Shortcuts/                          ← Siri ショートカット、URL ルータ、インポートと実行中継
 ├── Skills/                             ← Agent Skills のインポート、解析、GitHub 取得、リソース読み込み、ポリシー
@@ -178,9 +179,9 @@ ETOSCore/ETOSCore/                         ← プラットフォーム非依存
 ├── UsageAnalytics/                     ← 使用量イベント、ダッシュボード、時間単位トレンド、モデル別 Token 占有率
 └── Worldbook/                          ← Worldbook モデル、インポート／エクスポート、SQLite ストレージ、トリガーエンジン
 
-ETOS LLM Studio/ETOS LLM Studio iOS App/    ← iOS ビュー層（133 個の Swift ソースファイル）
-ETOS LLM Studio/ETOS LLM Studio Watch App/  ← watchOS ビュー層（111 個の Swift ソースファイル）
-ETOSCore/ETOSCoreTests/                         ← ETOSCore 層テスト（102 個の Swift ソースファイル）
+ETOS LLM Studio/ETOS LLM Studio iOS App/    ← iOS ビュー層（155 個の Swift ソースファイル）
+ETOS LLM Studio/ETOS LLM Studio Watch App/  ← watchOS ビュー層（131 個の Swift ソースファイル）
+ETOSCore/ETOSCoreTests/                         ← ETOSCore 層テスト（116 個の Swift ソースファイル）
 ```
 
 クラウドモデルのデータフローは `View → ChatViewModel → ChatService.shared → Provider Adapter → LLM API` です。ローカルモデルのデータフローは `View → ChatViewModel → ChatService.shared → LocalLLMEngine → LocalLLMBridge → libetos-llama.a / llama.cpp` です。セッション、ツール、記憶、Worldbook、使用量分析、同期データは ETOSCore 層サービスと GRDB / SQLite ストレージにより一元的に管理されます。
@@ -223,6 +224,33 @@ ETOSCore/ETOSCoreTests/                         ← ETOSCore 層テスト（102 
 
 ---
 
+## 🧪 自動テストとビルド
+
+コマンドラインで一括ビルドや単体テストを実行する場合は、以下の標準 `xcodebuild` コマンドを使用してください（環境変数の混入による watchOS リンク失敗を防ぐため環境変数をクリアしています）：
+
+* **iOS App のビルド（組み込み watch App を含む）**：
+  ```bash
+  env -u SDKROOT -u LIBRARY_PATH -u CPATH -u C_INCLUDE_PATH -u CPLUS_INCLUDE_PATH -u OBJC_INCLUDE_PATH xcodebuild -workspace 'ETOS LLM Studio.xcworkspace' -scheme 'ETOS LLM Studio App' -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.5' build
+  ```
+* **watchOS App ビルドの個別検証**：
+  ```bash
+  env -u SDKROOT -u LIBRARY_PATH -u CPATH -u C_INCLUDE_PATH -u CPLUS_INCLUDE_PATH -u OBJC_INCLUDE_PATH xcodebuild -workspace 'ETOS LLM Studio.xcworkspace' -scheme 'ETOS LLM Studio Watch App' -destination 'generic/platform=watchOS Simulator' build
+  ```
+* **ETOSCore コアフレームワークの単体テスト実行**（テストファイル 116 個、テストコード 41,055 行）：
+  ```bash
+  env -u SDKROOT -u LIBRARY_PATH -u CPATH -u C_INCLUDE_PATH -u CPLUS_INCLUDE_PATH -u OBJC_INCLUDE_PATH xcodebuild -workspace 'ETOS LLM Studio.xcworkspace' -scheme 'ETOSCore' -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.5' -parallel-testing-enabled NO test
+  ```
+* **iOS App 単体＆UI テストの実行**：
+  ```bash
+  env -u SDKROOT -u LIBRARY_PATH -u CPATH -u C_INCLUDE_PATH -u CPLUS_INCLUDE_PATH -u OBJC_INCLUDE_PATH xcodebuild -workspace 'ETOS LLM Studio.xcworkspace' -scheme 'ETOS LLM Studio App' -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.5' -parallel-testing-enabled NO test
+  ```
+* **watchOS App 単体＆UI テストの実行**：
+  ```bash
+  env -u SDKROOT -u LIBRARY_PATH -u CPATH -u C_INCLUDE_PATH -u CPLUS_INCLUDE_PATH -u OBJC_INCLUDE_PATH xcodebuild -workspace 'ETOS LLM Studio.xcworkspace' -scheme 'ETOS LLM Studio Watch App' -destination 'platform=watchOS Simulator,name=Apple Watch Series 11 (42mm),OS=26.5' -parallel-testing-enabled NO test
+  ```
+
+---
+
 ## 📬 連絡先
 
 *   **開発者**: Eric Terminal
@@ -231,4 +259,4 @@ ETOSCore/ETOSCoreTests/                         ← ETOSCore 層テスト（102 
 
 ---
 
-この README は 2026 年 6 月 9 日に更新されました（`cb7bf431` 以降のコミットを基準）。プロジェクトの更新速度はかなり速いので、README が追いついていない場合はコミット履歴のほうが正確です。
+この README は 2026 年 7 月 25 日に更新されました。プロジェクトの更新速度はかなり速いので、README が追いついていない場合はコミット履歴のほうが正確です。

--- a/docs/readme/README_RU.md
+++ b/docs/readme/README_RU.md
@@ -23,7 +23,7 @@
 
 В школе часто скучно, а вопросов к AI всегда слишком много. Когда я смотрела на приложения в App Store, почти все были либо слишком дорогими, либо слишком урезанными — особенно на Apple Watch. Поэтому я просто решила сделать своё.
 
-Изначально это был маленький эксперимент: около 1 800 строк и даже захардкоженные API‑ключи. Сейчас проект вырос до **641 Swift‑файла и 226 381 строки Swift‑кода** (только Swift внутри проекта; сабмодуль llama.cpp и зависимости VitePress doc‑сайта не учитываются). Название «ETOS LLM Studio» звучит громко, но по сути это всё ещё мой полигон для экспериментов с LLM‑приложениями.
+Изначально это был маленький эксперимент: около 1 800 строк и даже захардкоженные API‑ключи. Сейчас проект вырос до **758 Swift‑файлов и 284 139 строк Swift‑кода** (только Swift внутри проекта; сабмодуль llama.cpp и зависимости VitePress doc‑сайта не учитываются). Название «ETOS LLM Studio» звучит громко, но по сути это всё ещё мой полигон для экспериментов с LLM‑приложениями.
 
 Раньше это был почти чисто watch‑проект, а теперь iOS‑часть тоже стала полноценной: облачные модели, локальные GGUF‑веса, инструменты, память, worldbook, Daily Pulse и синхронизация между устройствами в одном приложении.
 
@@ -144,7 +144,7 @@
 Проект разделён на два уровня: платформенно‑независимый ETOSCore и отдельные UI‑слои для каждой платформы. В последнем рефакторинге появился настроечный хаб `Config/AppConfigStore`, полностью заменивший `@AppStorage`, а новые `LocalLLM` / `LocalLLMBridge` подключили локальный GGUF inference к существующему жизненному циклу чата. MCP, sync/import, LAN‑отладка и теги сессий также вынесены в отдельные модули. Самый большой Swift‑файл сейчас занимает около 1 540 строк (`Sync/WatchSyncManager.swift`); управление локальными моделями, sync engine и Tool Center остаются тяжёлыми модулями, которые стоит дальше постепенно разгружать.
 
 ```
-ETOSCore/ETOSCore/                         ← Общая бизнес-логика (293 Swift-файла)
+ETOSCore/ETOSCore/                         ← Общая бизнес-логика (349 Swift-файлов)
 ├── AppTool/                            ← Локальные инструменты, custom JS tools, ask_user_input, утилиты для SQLite и sandbox-файлов
 ├── Attachments/                        ← Извлечение текста из файловых вложений
 ├── Chat/                               ← Модели чата, версии сообщений, экспорт, состояние рендера
@@ -164,6 +164,7 @@ ETOSCore/ETOSCore/                         ← Общая бизнес-логи�
 ├── Parsing/                            ← Парсеры заголовков и параметрических выражений
 ├── Persistence/                        ← Основная/вспомогательные БД GRDB, миграции, startup-бэкап, медиа и файлы
 ├── Providers/                          ← Модели провайдеров, настройка прокси и адаптеры OpenAI / Anthropic / Gemini
+├── Roleplay/                           ← Персоны для ролевых игр, шаблоны промптов чата и пресеты персонажей
 ├── Security/                           ← Стейт-машина блокировки приложения, master-пароль PBKDF2 и менеджер шифрования БД
 ├── Shortcuts/                          ← Siri Shortcuts, URL-роутер, импорт и реле выполнения
 ├── Skills/                             ← Импорт Agent Skills, парсинг, загрузка с GitHub, чтение ресурсов и политики
@@ -176,9 +177,9 @@ ETOSCore/ETOSCore/                         ← Общая бизнес-логи�
 ├── UsageAnalytics/                     ← События использования, дашборды, почасовые тренды и доли токенов по моделям
 └── Worldbook/                          ← Модели worldbook, импорт/экспорт, SQLite-хранилище и движок триггеров
 
-ETOS LLM Studio/ETOS LLM Studio iOS App/    ← UI-слой iOS (133 Swift-файла)
-ETOS LLM Studio/ETOS LLM Studio Watch App/  ← UI-слой watchOS (111 Swift-файлов)
-ETOSCore/ETOSCoreTests/                         ← Тесты ETOSCore-слоя (102 Swift-файла)
+ETOS LLM Studio/ETOS LLM Studio iOS App/    ← UI-слой iOS (155 Swift-файлов)
+ETOS LLM Studio/ETOS LLM Studio Watch App/  ← UI-слой watchOS (131 Swift-файл)
+ETOSCore/ETOSCoreTests/                         ← Тесты ETOSCore-слоя (116 Swift-файлов)
 ```
 
 Поток данных для облачных моделей: `View → ChatViewModel → ChatService.shared → Provider Adapter → LLM API`. Поток данных для локальных моделей: `View → ChatViewModel → ChatService.shared → LocalLLMEngine → LocalLLMBridge → libetos-llama.a / llama.cpp`. Сессии, инструменты, память, worldbook, аналитика использования и синхронизация управляются сервисами слоя ETOSCore и хранилищем GRDB / SQLite.
@@ -218,6 +219,33 @@ ETOSCore/ETOSCoreTests/                         ← Тесты ETOSCore-слоя
 
 ---
 
+## 🧪 Автоматическое тестирование и сборка
+
+Для запуска сборки или модульного тестирования из командной строки используйте стандартные команды `xcodebuild` ниже (с изолированными переменными окружения для предотвращения сбоев):
+
+* **Сборка iOS App (включает встроенный watch App)**:
+  ```bash
+  env -u SDKROOT -u LIBRARY_PATH -u CPATH -u C_INCLUDE_PATH -u CPLUS_INCLUDE_PATH -u OBJC_INCLUDE_PATH xcodebuild -workspace 'ETOS LLM Studio.xcworkspace' -scheme 'ETOS LLM Studio App' -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.5' build
+  ```
+* **Отдельная проверка сборки watchOS App**:
+  ```bash
+  env -u SDKROOT -u LIBRARY_PATH -u CPATH -u C_INCLUDE_PATH -u CPLUS_INCLUDE_PATH -u OBJC_INCLUDE_PATH xcodebuild -workspace 'ETOS LLM Studio.xcworkspace' -scheme 'ETOS LLM Studio Watch App' -destination 'generic/platform=watchOS Simulator' build
+  ```
+* **Запуск модульных тестов фреймворка ETOSCore** (116 файлов тестов, 41 055 строк тестового кода):
+  ```bash
+  env -u SDKROOT -u LIBRARY_PATH -u CPATH -u C_INCLUDE_PATH -u CPLUS_INCLUDE_PATH -u OBJC_INCLUDE_PATH xcodebuild -workspace 'ETOS LLM Studio.xcworkspace' -scheme 'ETOSCore' -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.5' -parallel-testing-enabled NO test
+  ```
+* **Запуск Unit & UI-тестов iOS App**:
+  ```bash
+  env -u SDKROOT -u LIBRARY_PATH -u CPATH -u C_INCLUDE_PATH -u CPLUS_INCLUDE_PATH -u OBJC_INCLUDE_PATH xcodebuild -workspace 'ETOS LLM Studio.xcworkspace' -scheme 'ETOS LLM Studio App' -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.5' -parallel-testing-enabled NO test
+  ```
+* **Запуск Unit & UI-тестов watchOS App**:
+  ```bash
+  env -u SDKROOT -u LIBRARY_PATH -u CPATH -u C_INCLUDE_PATH -u CPLUS_INCLUDE_PATH -u OBJC_INCLUDE_PATH xcodebuild -workspace 'ETOS LLM Studio.xcworkspace' -scheme 'ETOS LLM Studio Watch App' -destination 'platform=watchOS Simulator,name=Apple Watch Series 11 (42mm),OS=26.5' -parallel-testing-enabled NO test
+  ```
+
+---
+
 ## 📬 Контакты
 
 *   **Разработчик**: Eric Terminal
@@ -226,4 +254,4 @@ ETOSCore/ETOSCoreTests/                         ← Тесты ETOSCore-слоя
 
 ---
 
-Этот README обновлён 9 июня 2026 года (на основе коммитов после `cb7bf431`). Если README не успел за кодом, смотрите историю коммитов.
+Этот README обновлён 25 июля 2026 года. Если README не успел за кодом, смотрите историю коммитов.

--- a/docs/readme/README_ZH_HANT.md
+++ b/docs/readme/README_ZH_HANT.md
@@ -23,7 +23,7 @@
 
 在學校的日子其實挺無聊的，平時又總有很多問題想問 AI。當時我覺得 App Store 上的 AI 應用不是貴得離譜，就是功能殘缺到不太想用，尤其是手錶端，所以乾脆自己動手做了一個。
 
-從最初那個只有 1,800 行程式碼、API Key 還要硬編碼的粗糙版本，到現在擁有 **641 個 Swift 原始碼檔案、226,381 行 Swift 程式碼**（僅計算專案內 Swift，不含 llama.cpp 子模組與 VitePress 文件站依賴）的工程，它確實已經長大了不少。雖然「ETOS LLM Studio」這個名字聽起來有點唬人，但本質上它還是我拿來探索大模型應用邊界的試驗場。
+從最初那個只有 1,800 行程式碼、API Key 還要硬編碼的粗糙版本，到現在擁有 **758 個 Swift 原始碼檔案、284,139 行 Swift 程式碼**（僅計算專案內 Swift，不含 llama.cpp 子模組與 VitePress 文件站依賴）的工程，它確實已經長大了不少。雖然「ETOS LLM Studio」這個名字聽起來有點唬人，但本質上它還是我拿來探索大模型應用邊界的試驗場。
 
 現在它也早就不只是手錶 App 了：我把 iOS 端慢慢補成了更完整的版本，方便在手機上管理雲端模型、本機 GGUF 權重、工具、記憶、世界書與每日脈衝；兩端資料還能透過內建同步引擎自動互通。
 
@@ -146,7 +146,7 @@
 專案採用雙層結構：平台無關的 ETOSCore 框架 + 各平台獨立的視圖層。最近一輪重構引入了 `Config/AppConfigStore` 設定中心，全面取代 `@AppStorage`，並新增 `LocalLLM` / `LocalLLMBridge` 把本機 GGUF 推理接入既有聊天生命週期；同時也把 MCP、同步匯入、局域網除錯與會話標籤繼續拆成獨立模組。當前最大的 Swift 檔案約 1,540 行（`Sync/WatchSyncManager.swift`），本地模型管理頁、同步引擎和工具中心仍屬於後續繼續拆分的重型模組。
 
 ```
-ETOSCore/ETOSCore/                         ← 平台無關業務邏輯（293 個 Swift 原始碼檔案）
+ETOSCore/ETOSCore/                         ← 平台無關業務邏輯（349 個 Swift 原始碼檔案）
 ├── AppTool/                            ← 本地工具、自訂 JS 工具、ask_user_input、SQLite 與沙盒檔案工具
 ├── Attachments/                        ← 檔案附件文字抽取
 ├── Chat/                               ← 聊天模型、訊息版本、匯出、渲染狀態
@@ -166,6 +166,7 @@ ETOSCore/ETOSCore/                         ← 平台無關業務邏輯（293 �
 ├── Parsing/                            ← 請求頭與參數表達式解析
 ├── Persistence/                        ← GRDB 主庫/輔助庫、遷移、啟動備份、媒體與檔案儲存
 ├── Providers/                          ← Provider 模型、代理設定與 OpenAI / Anthropic / Gemini 適配器
+├── Roleplay/                           ← 角色扮演人設、聊天提示詞範本與預設角色庫
 ├── Security/                           ← 應用鎖狀態機、PBKDF2 主密碼與資料庫加密管理
 ├── Shortcuts/                          ← Siri 捷徑、URL Router、匯入與執行中繼
 ├── Skills/                             ← Agent Skills 技能包匯入、解析、GitHub 拉取、資源讀取與策略
@@ -178,9 +179,9 @@ ETOSCore/ETOSCore/                         ← 平台無關業務邏輯（293 �
 ├── UsageAnalytics/                     ← 用量事件、統計儀表板、按小時趨勢與模型 Token 占比
 └── Worldbook/                          ← 世界書模型、匯入匯出、SQLite 儲存與觸發引擎
 
-ETOS LLM Studio/ETOS LLM Studio iOS App/    ← iOS 視圖層（133 個 Swift 原始碼檔案）
-ETOS LLM Studio/ETOS LLM Studio Watch App/  ← watchOS 視圖層（111 個 Swift 原始碼檔案）
-ETOSCore/ETOSCoreTests/                         ← ETOSCore 層測試（102 個 Swift 原始碼檔案）
+ETOS LLM Studio/ETOS LLM Studio iOS App/    ← iOS 視圖層（155 個 Swift 原始碼檔案）
+ETOS LLM Studio/ETOS LLM Studio Watch App/  ← watchOS 視圖層（131 個 Swift 原始碼檔案）
+ETOSCore/ETOSCoreTests/                         ← ETOSCore 層測試（116 個 Swift 原始碼檔案）
 ```
 
 雲端模型資料流：`View → ChatViewModel → ChatService.shared → Provider Adapter → LLM API`。本地模型資料流：`View → ChatViewModel → ChatService.shared → LocalLLMEngine → LocalLLMBridge → libetos-llama.a / llama.cpp`。會話、工具、記憶、世界書、用量統計與同步資料皆透過 ETOSCore 層服務和 GRDB / SQLite 儲存統一治理。
@@ -223,6 +224,33 @@ ETOSCore/ETOSCoreTests/                         ← ETOSCore 層測試（102 個
 
 ---
 
+## 🧪 自動化測試與構建
+
+如需在命令列執行一鍵編譯或單元測試，請統一使用以下標準 `xcodebuild` 命令（已配置隔離環境變數，避免本機環境污染導致的 watchOS 連結失敗）：
+
+* **構建 iOS App（自動包含 watch App）**：
+  ```bash
+  env -u SDKROOT -u LIBRARY_PATH -u CPATH -u C_INCLUDE_PATH -u CPLUS_INCLUDE_PATH -u OBJC_INCLUDE_PATH xcodebuild -workspace 'ETOS LLM Studio.xcworkspace' -scheme 'ETOS LLM Studio App' -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.5' build
+  ```
+* **單獨驗證 watchOS App 構建**：
+  ```bash
+  env -u SDKROOT -u LIBRARY_PATH -u CPATH -u C_INCLUDE_PATH -u CPLUS_INCLUDE_PATH -u OBJC_INCLUDE_PATH xcodebuild -workspace 'ETOS LLM Studio.xcworkspace' -scheme 'ETOS LLM Studio Watch App' -destination 'generic/platform=watchOS Simulator' build
+  ```
+* **運行 ETOSCore 核心框架單元測試**（116 個測試原始碼檔案，41,055 行測試程式碼）：
+  ```bash
+  env -u SDKROOT -u LIBRARY_PATH -u CPATH -u C_INCLUDE_PATH -u CPLUS_INCLUDE_PATH -u OBJC_INCLUDE_PATH xcodebuild -workspace 'ETOS LLM Studio.xcworkspace' -scheme 'ETOSCore' -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.5' -parallel-testing-enabled NO test
+  ```
+* **運行 iOS App 單元與 UI 測試**：
+  ```bash
+  env -u SDKROOT -u LIBRARY_PATH -u CPATH -u C_INCLUDE_PATH -u CPLUS_INCLUDE_PATH -u OBJC_INCLUDE_PATH xcodebuild -workspace 'ETOS LLM Studio.xcworkspace' -scheme 'ETOS LLM Studio App' -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.5' -parallel-testing-enabled NO test
+  ```
+* **運行 watchOS App 單元與 UI 測試**：
+  ```bash
+  env -u SDKROOT -u LIBRARY_PATH -u CPATH -u C_INCLUDE_PATH -u CPLUS_INCLUDE_PATH -u OBJC_INCLUDE_PATH xcodebuild -workspace 'ETOS LLM Studio.xcworkspace' -scheme 'ETOS LLM Studio Watch App' -destination 'platform=watchOS Simulator,name=Apple Watch Series 11 (42mm),OS=26.5' -parallel-testing-enabled NO test
+  ```
+
+---
+
 ## 📬 聯絡方式
 
 *   **開發者**: Eric Terminal
@@ -231,4 +259,4 @@ ETOSCore/ETOSCoreTests/                         ← ETOSCore 層測試（102 個
 
 ---
 
-本次 README 修訂於 2026 年 6 月 9 日（基於 `cb7bf431` 之後的提交）。專案更新速度很快，如果 README 一時跟不上程式碼，最準的還是提交記錄。
+本次 README 修訂於 2026 年 7 月 25 日。專案更新速度很快，如果 README 一時跟不上程式碼，最準的還是提交記錄。


### PR DESCRIPTION
## 改动内容

- **代码规模与源文件数据更新**：将 `README.md` 及 4 个多语言 README 文档（英文、繁体中文、日文、俄文）中的 Swift 代码统计更新为最新实测数据（**758 个 Swift 源文件、284,139 行 Swift 代码**），并按 ETOSCore 核心、ETOSCoreTests 单元测试、iOS 视图层与 watchOS 视图层分别列出细分数据。
- **补充架构树模块**：在 `ETOSCore/ETOSCore/` 目录树中补齐 `Roleplay/`（角色扮演人设、聊天提示词模板与预置角色库）模块，修正各模块文件数统计。
- **新增命令行构建与测试指南**：在编译指南后新增 `🧪 自动化测试与构建` 章节，提供带有环境变量隔离（`-u SDKROOT -u LIBRARY_PATH` 等）的标准 `xcodebuild` 命令行指南（包含 iOS App、watchOS App 独立构建与 ETOSCore/iOS/watchOS 测试命令）。
- **同步多语言 README 与修订日期**：完成 `README_EN.md`、`README_ZH_HANT.md`、`README_JA.md`、`README_RU.md` 的多语言同步，并将各 README 尾部修订日期更新至 **2026 年 7 月 25 日**。

## 验证

- 手动检查主 `README.md` 与多语言 README 的 Markdown 渲染、代码块语法、相对路径及表格无报错。
- 通过 `git status` 与 Python 统计脚本重新校验全项目 758 个 Swift 文件及 284,139 行代码数据无误。

## 截图或录屏

- 不适用（纯文档更新）。

## CLA

- [x] I have read the CLA Document and I hereby sign the CLA.

## Summary by Sourcery

Update project documentation to reflect current Swift codebase size and testing setup.

Documentation:
- Refresh main and multilingual READMEs with updated Swift file and line counts and revised ETOSCore/iOS/watchOS module statistics.
- Document the Roleplay module in the ETOSCore directory tree across all README variants.
- Add an automated testing and CLI build section with standardized xcodebuild commands for apps and ETOSCore tests in all languages.
- Update README revision dates to July 25, 2026 in the main and localized documentation.