### PR TITLE
feat(landing): 重构更新宣传主页并优化磁吸光标延迟

### DIFF
--- a/docs/landing/src/App.vue
+++ b/docs/landing/src/App.vue
@@ -7,6 +7,9 @@ import { useMagneticCursor } from './composables/useMagneticCursor.js';
 import { useTheme } from './composables/useTheme.js';
 import { useLang } from './composables/useLang.js';
 
+import LocalModelDemo from './components/LocalModelDemo.vue';
+import McpSkillsDemo from './components/McpSkillsDemo.vue';
+
 const REPO_URL = 'https://github.com/Eric-Terminal/ETOS-LLM-Studio';
 const DOCS_URL = 'https://etos-llm-studio-docs.pages.dev';
 const QUICKSTART_PATH = '/guide/getting-started';
@@ -19,7 +22,6 @@ const { current: currentLang, list: langList, set: setLang } = useLang();
 
 const text = computed(() => translations[currentLang.value] ?? translations.zh);
 const docsHref = computed(() => {
-  // 中文/英文走对应路径，其它语言暂时回落英文版。
   const lang = currentLang.value;
   if (lang === 'zh' || lang === 'zh-Hant') return `${DOCS_URL}${QUICKSTART_PATH}`;
   return `${DOCS_URL}/en${QUICKSTART_PATH}`;
@@ -31,12 +33,10 @@ const modulesHref = computed(() => {
 });
 
 const titleLetters = computed(() => {
-  // 把标题切成字符数组，CJK 单字也独立动画。空格保留。
   return Array.from(text.value.hero.title);
 });
 
-// 个性化预览：三项真实外观功能——上传壁纸 / 对话框颜色（调色盘）/ 去掉 AI 气泡。
-// 默认值对齐 App：Telegram 浅蓝灰壁纸 + Telegram 蓝气泡（rgb 0.24,0.56,0.95）。
+// 个性化预览
 const DEFAULT_BUBBLE = '#3477d3';
 const DEFAULT_WALL = 'linear-gradient(180deg, #d9e6eb 0%, #e0ebf2 100%)';
 
@@ -44,7 +44,6 @@ const bubbleColor = ref(DEFAULT_BUBBLE);
 const wallpaperUrl = ref('');
 const hideBotBubble = ref(false);
 
-// 把 hex 按比例压暗，模拟 App 用户气泡渐变的深色端（darkened factor 0.86）。
 function darkenHex(hex, factor) {
   const n = hex.replace('#', '');
   if (n.length !== 6) return hex;
@@ -75,18 +74,18 @@ function resetPersona() {
   hideBotBubble.value = false;
 }
 
-// 滚动 marquee：统一英文，不走 i18n。
 const marqueeItems = [
   'OpenAI',
   'Anthropic Claude',
   'Google Gemini',
-  'OpenAI-compatible',
-  'MCP',
+  'llama.cpp Local GGUF',
+  'MCP SDK',
   'Agent Skills',
-  'Shortcuts',
+  'SQLCipher',
   'Local RAG',
   'Worldbook',
-  'Daily Pulse'
+  'Daily Pulse',
+  'WatchConnectivity'
 ];
 
 const isLangMenuOpen = ref(false);
@@ -103,7 +102,6 @@ function onDocClick(event) {
   }
 }
 
-// 滚动进度条 + 回到顶部
 const scrollProgress = ref(0);
 const showBackToTop = ref(false);
 function onScroll() {
@@ -115,7 +113,6 @@ function backToTop() {
   window.scrollTo({ top: 0, behavior: 'smooth' });
 }
 
-// 顶部条在滚动到一定距离后压缩高度
 const isCondensed = ref(false);
 function onScrollCondense() {
   isCondensed.value = window.scrollY > 24;
@@ -138,7 +135,7 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <!-- 开屏遮罩 + 波浪噪声动画 -->
+  <!-- 开屏遮罩 -->
   <div
     v-if="showLoader"
     class="loader-screen"
@@ -167,7 +164,6 @@ onBeforeUnmount(() => {
     </div>
   </div>
 
-  <!-- 加载结束后波浪不销毁，作为背景纹理在两侧渐显 -->
   <svg
     class="loader-waves persistent-waves"
     :class="{ 'is-visible': !showLoader }"
@@ -176,7 +172,6 @@ onBeforeUnmount(() => {
     <path v-for="(p, i) in wavePaths" :key="`p-${i}`" :d="p.d" />
   </svg>
 
-  <!-- 四边收束的边框 -->
   <div
     v-if="showFrame"
     class="site-frame"
@@ -205,6 +200,8 @@ onBeforeUnmount(() => {
       <span class="brand-name">ETOS LLM Studio</span>
     </a>
     <div class="nav-right">
+      <a class="nav-link" href="#local-model">{{ text.nav.localModel }}</a>
+      <a class="nav-link" href="#mcp-skills">{{ text.nav.mcpSkills }}</a>
       <a class="nav-link" href="#features">{{ text.nav.features }}</a>
       <a class="nav-link" href="#personalize">{{ text.nav.personalize }}</a>
       <a class="nav-link" href="#privacy">{{ text.nav.privacy }}</a>
@@ -216,7 +213,7 @@ onBeforeUnmount(() => {
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" width="14" height="14">
             <circle cx="12" cy="12" r="9" />
             <line x1="3" y1="12" x2="21" y2="12" />
-            <path d="M12 3a14 14 0 0 1 4 9 14 14 0 0 1-4 9 14 14 0 0 1-4-9 14 14 0 0 1 4-9z" />
+            <path d="M12 3a14 14 0 0 1 4 9 14 14 0 0 1-4 9 14 14 0 0 1-4-9z" />
           </svg>
           <span class="lang-current">{{ langList.find((l) => l.code === currentLang)?.name }}</span>
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" width="12" height="12">
@@ -263,7 +260,7 @@ onBeforeUnmount(() => {
         <span></span><span></span><span></span><span></span><span></span><span></span>
       </div>
       <div class="hero-inner">
-        <div class="section-label">NATIVE · iOS 18 · watchOS 11</div>
+        <div class="section-label">NATIVE · iOS 18 · watchOS 11 · GGUF LOCAL LLM</div>
         <h1 class="hero-title" :aria-label="text.hero.title">
           <span
             v-for="(letter, i) in titleLetters"
@@ -296,6 +293,18 @@ onBeforeUnmount(() => {
       </div>
     </section>
 
+    <!-- STATS COUNTERS BAR -->
+    <section class="stats-counter-section">
+      <div class="container">
+        <div class="stats-grid">
+          <div v-for="(s, idx) in text.stats" :key="idx" class="stat-box">
+            <div class="stat-val-huge">{{ s.val }}</div>
+            <div class="stat-lbl">{{ s.label }}</div>
+          </div>
+        </div>
+      </div>
+    </section>
+
     <!-- 滚动横向 marquee -->
     <section class="marquee" aria-hidden="true">
       <div class="marquee-track">
@@ -304,8 +313,28 @@ onBeforeUnmount(() => {
       </div>
     </section>
 
+    <!-- 端侧 GGUF 本地模型 INTERACTIVE DEMO -->
+    <section id="local-model" class="local-demo-section tile-dark">
+      <div class="container">
+        <div class="section-label section-label-light">ON-DEVICE INFERENCE</div>
+        <h2 class="tile-title">{{ text.localDemo.title }}</h2>
+        <p class="tile-lead">{{ text.localDemo.lead }}</p>
+        <LocalModelDemo :text="text" />
+      </div>
+    </section>
+
+    <!-- MCP 协议 & AGENT SKILLS INTERACTIVE DEMO -->
+    <section id="mcp-skills" class="mcp-skills-section tile-parchment">
+      <div class="container">
+        <div class="section-label">EXTENSIBLE TOOLKIT</div>
+        <h2 class="tile-title">{{ text.mcpSkillsSection.title }}</h2>
+        <p class="tile-lead">{{ text.mcpSkillsSection.lead }}</p>
+        <McpSkillsDemo :text="text" />
+      </div>
+    </section>
+
     <!-- 截图 -->
-    <section class="screenshots tile-parchment" v-reveal>
+    <section class="screenshots tile-light">
       <div class="container">
         <div class="section-label">SCREENSHOTS · CURRENT BUILD</div>
         <h2 class="tile-title">{{ text.screenshots.title }}</h2>
@@ -328,14 +357,13 @@ onBeforeUnmount(() => {
     </section>
 
     <!-- 个性化外观 -->
-    <section id="personalize" class="personalize tile-light" v-reveal>
+    <section id="personalize" class="personalize tile-parchment">
       <div class="container">
         <div class="section-label">MAKE IT YOURS</div>
         <h2 class="tile-title">{{ text.personalize.title }}</h2>
         <p class="tile-lead">{{ text.personalize.lead }}</p>
 
         <div class="persona-stage">
-          <!-- 左：三项真实外观功能 -->
           <div class="persona-controls">
             <div class="persona-picker-hint">
               <span class="persona-live-dot" aria-hidden="true"></span>
@@ -356,7 +384,7 @@ onBeforeUnmount(() => {
               </label>
             </div>
 
-            <!-- 2. 对话框颜色（调色盘） -->
+            <!-- 2. 对话框颜色 -->
             <div class="persona-control persona-control-row">
               <span class="persona-control-label">{{ text.personalize.colorLabel }}</span>
               <label class="persona-colorpicker">
@@ -384,7 +412,7 @@ onBeforeUnmount(() => {
             <button class="persona-reset" type="button" @click="resetPersona">{{ text.personalize.reset }}</button>
           </div>
 
-          <!-- 右：仿 iPhone 聊天界面，随预设实时换肤 -->
+          <!-- 右：仿 iPhone 聊天界面 -->
           <div class="persona-phone-wrap">
             <div class="persona-phone" :style="phoneStyle">
               <img class="persona-frame" src="/images/phone-frame.svg" alt="" aria-hidden="true" />
@@ -398,8 +426,6 @@ onBeforeUnmount(() => {
                         <path transform="translate(77,17)" d="M8 14.2C8 14.2 1.2 9.9 1.2 5.4 1.2 3.1 2.9 1.6 4.8 1.6 6.1 1.6 7.3 2.4 8 3.6 8.7 2.4 9.9 1.6 11.2 1.6 13.1 1.6 14.8 3.1 14.8 5.4 14.8 9.9 8 14.2 8 14.2Z" />
                         <path transform="translate(10,54)" d="M1.2 7.4 14.8 1.4 8.8 14.8 7 8.8Z" />
                         <path transform="translate(62,50)" d="M3.5 2H12.5A2 2 0 0 1 14.5 4V9A2 2 0 0 1 12.5 11H6.5L3.5 13.8V11A2 2 0 0 1 1.5 9V4A2 2 0 0 1 3.5 2Z" />
-                        <path transform="translate(40,90)" d="M8 14.2C8 14.2 1.2 9.9 1.2 5.4 1.2 3.1 2.9 1.6 4.8 1.6 6.1 1.6 7.3 2.4 8 3.6 8.7 2.4 9.9 1.6 11.2 1.6 13.1 1.6 14.8 3.1 14.8 5.4 14.8 9.9 8 14.2 8 14.2Z" />
-                        <path transform="translate(92,84)" d="M8 0.6 9.9 5.4 15 5.8 11.1 9.1 12.4 14.1 8 11.3 3.6 14.1 4.9 9.1 1 5.8 6.1 5.4Z" />
                       </g>
                     </pattern>
                   </defs>
@@ -418,7 +444,7 @@ onBeforeUnmount(() => {
                       <rect x="9.2" y="3" width="3" height="9" rx="1" />
                       <rect x="13.8" y="0" width="3" height="12" rx="1" />
                     </svg>
-                    <span class="persona-net">4G</span>
+                    <span class="persona-net">5G</span>
                     <svg class="persona-batt" viewBox="0 0 26 12" fill="none">
                       <rect x="0.6" y="0.6" width="21.5" height="10.8" rx="3" stroke="currentColor" stroke-opacity="0.4" />
                       <rect x="2" y="2" width="18" height="8" rx="1.6" fill="currentColor" />
@@ -427,7 +453,7 @@ onBeforeUnmount(() => {
                   </span>
                 </div>
                 <div class="persona-nav">
-                  <span class="persona-nav-btn" v-liquid-glass aria-hidden="true">
+                  <span class="persona-nav-btn" aria-hidden="true">
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round">
                       <circle cx="4.6" cy="7" r="1.15" fill="currentColor" stroke="none" />
                       <line x1="9" y1="7" x2="20" y2="7" />
@@ -437,16 +463,16 @@ onBeforeUnmount(() => {
                       <line x1="9" y1="17" x2="20" y2="17" />
                     </svg>
                   </span>
-                  <span class="persona-nav-pill" v-liquid-glass>
+                  <span class="persona-nav-pill">
                     <span class="persona-nav-texts">
                       <span class="persona-nav-title">{{ text.personalize.chat.title }}</span>
-                      <span class="persona-nav-sub">GPT-5.5 · OpenAI</span>
+                      <span class="persona-nav-sub">Qwen2.5-7B · GGUF Local</span>
                     </span>
                     <svg class="persona-nav-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                       <polyline points="6 9 12 15 18 9" />
                     </svg>
                   </span>
-                  <span class="persona-nav-btn" v-liquid-glass aria-hidden="true">
+                  <span class="persona-nav-btn" aria-hidden="true">
                     <svg viewBox="0 0 24 24" fill="currentColor">
                       <path d="M19.14 12.94c.04-.3.06-.61.06-.94 0-.32-.02-.64-.07-.94l2.03-1.58a.49.49 0 0 0 .12-.61l-1.92-3.32a.488.488 0 0 0-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54a.484.484 0 0 0-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96c-.22-.08-.47 0-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.05.3-.09.63-.09.94s.02.64.07.94l-2.03 1.58a.49.49 0 0 0-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61l-2.01-1.58zM12 15.6c-1.98 0-3.6-1.62-3.6-3.6s1.62-3.6 3.6-3.6 3.6 1.62 3.6 3.6-1.62 3.6-3.6 3.6z" />
                     </svg>
@@ -454,21 +480,21 @@ onBeforeUnmount(() => {
                 </div>
                 <div class="persona-messages">
                   <div class="persona-row persona-row-user">
-                    <div class="persona-bubble persona-bubble-user" v-liquid-glass="{ blur: 1 }"><span class="persona-btext">{{ text.personalize.chat.user }}</span></div>
+                    <div class="persona-bubble persona-bubble-user"><span class="persona-btext">{{ text.personalize.chat.user }}</span></div>
                   </div>
                   <div class="persona-row persona-row-bot">
-                    <div v-if="!hideBotBubble" class="persona-bubble persona-bubble-bot" v-liquid-glass="{ blur: 6 }"><span class="persona-btext">{{ text.personalize.chat.bot }}</span></div>
+                    <div v-if="!hideBotBubble" class="persona-bubble persona-bubble-bot"><span class="persona-btext">{{ text.personalize.chat.bot }}</span></div>
                     <div v-else class="persona-bubble persona-bubble-bot persona-bubble-bot--bare"><span class="persona-btext">{{ text.personalize.chat.bot }}</span></div>
                   </div>
                 </div>
                 <div class="persona-inputbar">
-                  <span class="persona-circle persona-clip" v-liquid-glass aria-hidden="true">
+                  <span class="persona-circle persona-clip" aria-hidden="true">
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
                       <path d="M20.5 11.5l-8.4 8.4a4.5 4.5 0 0 1-6.4-6.4l8.5-8.5a3 3 0 0 1 4.3 4.3l-8.5 8.5a1.5 1.5 0 0 1-2.1-2.1l7.8-7.8" />
                     </svg>
                   </span>
-                  <span class="persona-input" v-liquid-glass><span class="persona-input-text">{{ text.personalize.chat.placeholder }}</span></span>
-                  <span class="persona-circle persona-send" v-liquid-glass aria-hidden="true">
+                  <span class="persona-input"><span class="persona-input-text">{{ text.personalize.chat.placeholder }}</span></span>
+                  <span class="persona-circle persona-send" aria-hidden="true">
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round">
                       <line x1="12" y1="19" x2="12" y2="5" />
                       <polyline points="6 11 12 5 18 11" />
@@ -482,8 +508,8 @@ onBeforeUnmount(() => {
       </div>
     </section>
 
-    <!-- 功能 -->
-    <section id="features" class="features tile-dark" v-reveal>
+    <!-- 功能矩阵 -->
+    <section id="features" class="features tile-dark">
       <div class="container">
         <div class="section-label section-label-light">FEATURE MATRIX</div>
         <h2 class="tile-title">{{ text.features.title }}</h2>
@@ -493,7 +519,6 @@ onBeforeUnmount(() => {
             v-for="(item, idx) in text.features.items"
             :key="idx"
             class="feature-card"
-            v-reveal
             :style="{ '--card-delay': `${idx * 0.06}s` }"
           >
             <div class="feature-kicker">{{ item.kicker }}</div>
@@ -508,7 +533,7 @@ onBeforeUnmount(() => {
     </section>
 
     <!-- 隐私 -->
-    <section id="privacy" class="privacy tile-light" v-reveal>
+    <section id="privacy" class="privacy tile-light">
       <div class="container">
         <div class="section-label">PRIVACY & LOCAL-FIRST</div>
         <h2 class="tile-title">{{ text.privacy.title }}</h2>
@@ -518,7 +543,6 @@ onBeforeUnmount(() => {
             v-for="(b, idx) in text.privacy.bullets"
             :key="idx"
             class="privacy-card"
-            v-reveal
           >
             <div class="privacy-kicker">{{ b.kicker }}</div>
             <div class="privacy-card-title">{{ b.title }}</div>
@@ -529,13 +553,13 @@ onBeforeUnmount(() => {
     </section>
 
     <!-- 技术栈 -->
-    <section id="tech" class="tech tile-parchment" v-reveal>
+    <section id="tech" class="tech tile-parchment">
       <div class="container">
         <div class="section-label">TECH STACK</div>
         <h2 class="tile-title">{{ text.tech.title }}</h2>
         <p class="tile-lead">{{ text.tech.lead }}</p>
         <div class="tech-grid">
-          <div v-for="(t, idx) in text.tech.items" :key="idx" class="stat-card" v-reveal>
+          <div v-for="(t, idx) in text.tech.items" :key="idx" class="stat-card">
             <div class="stat-name">{{ t.name }}</div>
             <div class="stat-desc">{{ t.desc }}</div>
           </div>
@@ -544,7 +568,7 @@ onBeforeUnmount(() => {
     </section>
 
     <!-- CTA -->
-    <section class="cta tile-dark" v-reveal>
+    <section class="cta tile-dark">
       <div class="container cta-inner">
         <div class="section-label section-label-light">READY TO START</div>
         <h2 class="cta-title">{{ text.cta.title }}</h2>

--- a/docs/landing/src/components/LocalModelDemo.vue
+++ b/docs/landing/src/components/LocalModelDemo.vue
@@ -22,22 +22,27 @@ const currentModel = computed(() => {
     name: 'Qwen2.5-7B-Instruct.Q4_K_M.gguf',
     size: '4.35 GB',
     thinking: '',
-    response: ''
+    response: '',
+    hud: {}
   };
 
   const isMetal = metalOffload.value;
   const isFlash = flashAttention.value;
   const isKV = kvCache.value;
+  const hud = base.hud || {};
 
-  // Calculate dynamic HUD stats based on hardware toggles including kvCache
-  let cpu = isMetal ? '18%' : '78%';
-  let gpu = isMetal ? '92%' : '0%';
-  let ram = isMetal
-    ? (isKV ? '4.2 GB (Metal)' : '4.8 GB (Metal)')
-    : (isKV ? '4.5 GB (RAM)' : '5.1 GB (RAM)');
-  let speedVal = isFlash
-    ? (isKV ? 42.6 : 38.4)
-    : (isKV ? 25.8 : 22.1);
+  const cpu = isMetal
+    ? (hud.cpuMetal || '18%')
+    : (hud.cpuOnly || '78%');
+  const gpu = isMetal
+    ? (hud.gpuMetal || '92%')
+    : '0%';
+  const ram = isMetal
+    ? (isKV ? (hud.ramMetalKV || '5.2 GB (Metal + KV)') : (hud.ramMetal || '4.8 GB (Metal)'))
+    : (isKV ? (hud.ramCpuKV || '5.8 GB (RAM + KV)') : (hud.ramCpu || '5.1 GB (RAM)'));
+  const speedVal = isFlash
+    ? (isKV ? (hud.speedFlashKV || 42.6) : (hud.speedFlash || 38.4))
+    : (isKV ? (hud.speedKV || 25.8) : (hud.speedBase || 22.1));
 
   return {
     ...base,

--- a/docs/landing/src/components/LocalModelDemo.vue
+++ b/docs/landing/src/components/LocalModelDemo.vue
@@ -11,7 +11,7 @@ const props = defineProps({
 const selectedModelIndex = ref(0);
 const metalOffload = ref(true);
 const flashAttention = ref(true);
-const kvCache = ref(true);
+const kvCache = ref(false);
 
 const localDemoText = computed(() => props.text.localDemo || {});
 
@@ -41,8 +41,8 @@ const currentModel = computed(() => {
     ? (isKV ? (hud.ramMetalKV || '5.2 GB (Metal + KV)') : (hud.ramMetal || '4.8 GB (Metal)'))
     : (isKV ? (hud.ramCpuKV || '5.8 GB (RAM + KV)') : (hud.ramCpu || '5.1 GB (RAM)'));
   const speedVal = isFlash
-    ? (isKV ? (hud.speedFlashKV || 42.6) : (hud.speedFlash || 38.4))
-    : (isKV ? (hud.speedKV || 25.8) : (hud.speedBase || 22.1));
+    ? (hud.speedFlash || 38.4)
+    : (hud.speedBase || 22.1);
 
   return {
     ...base,
@@ -51,8 +51,8 @@ const currentModel = computed(() => {
     cpuUtil: cpu,
     speed: `${speedVal} t/s`,
     kvStatusLabel: isKV
-      ? (localDemoText.value.kvCacheActiveLabel || 'KV Cache Reused')
-      : (localDemoText.value.kvCacheInactiveLabel || 'KV Cache Off')
+      ? localDemoText.value.kvCacheEnabledLabel
+      : localDemoText.value.kvCacheDisabledLabel
   };
 });
 </script>
@@ -61,8 +61,8 @@ const currentModel = computed(() => {
   <div class="local-demo-wrapper">
     <div class="local-demo-controls">
       <div class="control-header">
-        <span class="control-badge">GGUF · llama.cpp C ABI</span>
-        <span class="control-title">{{ localDemoText.selectModelLabel || 'Select Local GGUF Model' }}</span>
+        <span class="control-badge">{{ localDemoText.controlBadge }}</span>
+        <span class="control-title">{{ localDemoText.selectModelLabel }}</span>
       </div>
 
       <div class="model-buttons">
@@ -72,6 +72,7 @@ const currentModel = computed(() => {
           type="button"
           class="model-chip-btn"
           :class="{ active: selectedModelIndex === i }"
+          :aria-pressed="selectedModelIndex === i"
           @click="selectedModelIndex = i"
         >
           <span class="chip-name">{{ m.name.split('.')[0] }}</span>
@@ -83,43 +84,44 @@ const currentModel = computed(() => {
         <label class="toggle-item">
           <input type="checkbox" v-model="metalOffload" />
           <span class="toggle-box"></span>
-          <span class="toggle-text">Metal GPU Offload</span>
+          <span class="toggle-text">{{ localDemoText.metalOffloadLabel }}</span>
         </label>
 
         <label class="toggle-item">
           <input type="checkbox" v-model="flashAttention" />
           <span class="toggle-box"></span>
-          <span class="toggle-text">Flash Attention</span>
+          <span class="toggle-text">{{ localDemoText.flashAttentionLabel }}</span>
         </label>
 
         <label class="toggle-item">
           <input type="checkbox" v-model="kvCache" />
           <span class="toggle-box"></span>
-          <span class="toggle-text">KV Cache Prefix Reuse</span>
+          <span class="toggle-text">{{ localDemoText.kvCacheLabel }}</span>
         </label>
       </div>
 
-      <!-- Real-time HUD stats -->
+      <!-- 这里展示估算数据，真实性能取决于设备、量化与上下文。 -->
       <div class="hud-stats-grid">
         <div class="hud-stat">
-          <div class="stat-label">CPU LOAD</div>
+          <div class="stat-label">{{ localDemoText.cpuLoadLabel }}</div>
           <div class="stat-val">{{ currentModel.cpuUtil }}</div>
           <div class="stat-bar-track"><div class="stat-bar-fill" :style="{ width: currentModel.cpuUtil }"></div></div>
         </div>
         <div class="hud-stat">
-          <div class="stat-label">METAL GPU</div>
+          <div class="stat-label">{{ localDemoText.metalGPULabel }}</div>
           <div class="stat-val">{{ currentModel.gpuUtil }}</div>
           <div class="stat-bar-track"><div class="stat-bar-fill metal" :style="{ width: currentModel.gpuUtil }"></div></div>
         </div>
         <div class="hud-stat">
-          <div class="stat-label">MEMORY</div>
+          <div class="stat-label">{{ localDemoText.memoryLabel }}</div>
           <div class="stat-val">{{ currentModel.ram }}</div>
         </div>
         <div class="hud-stat">
-          <div class="stat-label">SPEED</div>
+          <div class="stat-label">{{ localDemoText.speedLabel }}</div>
           <div class="stat-val highlight">{{ currentModel.speed }}</div>
         </div>
       </div>
+      <p class="hud-estimate-note">{{ localDemoText.estimateDisclaimer }}</p>
     </div>
 
     <div class="local-demo-screen">

--- a/docs/landing/src/components/LocalModelDemo.vue
+++ b/docs/landing/src/components/LocalModelDemo.vue
@@ -1,0 +1,155 @@
+<script setup>
+import { ref, computed } from 'vue';
+
+const props = defineProps({
+  text: {
+    type: Object,
+    required: true
+  }
+});
+
+const selectedModelIndex = ref(0);
+const metalOffload = ref(true);
+const flashAttention = ref(true);
+const kvCache = ref(true);
+
+const models = computed(() => [
+  {
+    name: 'Qwen2.5-7B-Instruct.Q4_K_M.gguf',
+    size: '4.35 GB',
+    ram: metalOffload.value ? '4.8 GB (Metal)' : '5.1 GB (RAM)',
+    gpuUtil: metalOffload.value ? '88%' : '0%',
+    cpuUtil: metalOffload.value ? '18%' : '76%',
+    speed: flashAttention.value ? '38.4 t/s' : '22.1 t/s',
+    thinking: '正在使用本地端侧权重视觉/逻辑推理，针对问答结构与格式进行编译处理...',
+    response: '根据离线知识库与 GRDB 本地索引，当前系统硬件加速正常启用。'
+  },
+  {
+    name: 'DeepSeek-R1-Distill-Q4_K_S.gguf',
+    size: '4.10 GB',
+    ram: metalOffload.value ? '4.5 GB (Metal)' : '4.8 GB (RAM)',
+    gpuUtil: metalOffload.value ? '94%' : '0%',
+    cpuUtil: metalOffload.value ? '12%' : '84%',
+    speed: flashAttention.value ? '42.8 t/s' : '26.5 t/s',
+    thinking: '分析思考链路：1. 检索本地 SQLite 数据库；2. 解析 GGUF Jinja Chat Template；3. 生成流式思考步骤与最终结论...',
+    response: 'DeepSeek-R1 本地推理完成！思考耗时 1.2 秒，全流式 Metal GPU 加速输出。'
+  },
+  {
+    name: 'Llama-3.1-8B-Instruct.Q4_K_M.gguf',
+    size: '4.92 GB',
+    ram: metalOffload.value ? '5.4 GB (Metal)' : '5.8 GB (RAM)',
+    gpuUtil: metalOffload.value ? '82%' : '0%',
+    cpuUtil: metalOffload.value ? '22%' : '68%',
+    speed: flashAttention.value ? '34.2 t/s' : '19.8 t/s',
+    thinking: 'Checking local GGUF memory budget and KV cache allocation...',
+    response: 'Llama 3.1 8B local execution complete. All memory and KV offload operating strictly within sandbox limits.'
+  }
+]);
+
+const currentModel = computed(() => models.value[selectedModelIndex.value]);
+</script>
+
+<template>
+  <div class="local-demo-wrapper">
+    <div class="local-demo-controls">
+      <div class="control-header">
+        <span class="control-badge">GGUF · llama.cpp C ABI</span>
+        <span class="control-title">{{ text.localDemo?.selectModelLabel || '选择本地 GGUF 模型' }}</span>
+      </div>
+
+      <div class="model-buttons">
+        <button
+          v-for="(m, i) in models"
+          :key="i"
+          type="button"
+          class="model-chip-btn"
+          :class="{ active: selectedModelIndex === i }"
+          @click="selectedModelIndex = i"
+        >
+          <span class="chip-name">{{ m.name.split('.')[0] }}</span>
+          <span class="chip-size">{{ m.size }}</span>
+        </button>
+      </div>
+
+      <div class="hardware-toggles">
+        <label class="toggle-item">
+          <input type="checkbox" v-model="metalOffload" />
+          <span class="toggle-box"></span>
+          <span class="toggle-text">Metal GPU Offload</span>
+        </label>
+
+        <label class="toggle-item">
+          <input type="checkbox" v-model="flashAttention" />
+          <span class="toggle-box"></span>
+          <span class="toggle-text">Flash Attention</span>
+        </label>
+
+        <label class="toggle-item">
+          <input type="checkbox" v-model="kvCache" />
+          <span class="toggle-box"></span>
+          <span class="toggle-text">KV Cache Offload</span>
+        </label>
+      </div>
+
+      <!-- Real-time HUD stats -->
+      <div class="hud-stats-grid">
+        <div class="hud-stat">
+          <div class="stat-label">CPU LOAD</div>
+          <div class="stat-val">{{ currentModel.cpuUtil }}</div>
+          <div class="stat-bar-track"><div class="stat-bar-fill" :style="{ width: currentModel.cpuUtil }"></div></div>
+        </div>
+        <div class="hud-stat">
+          <div class="stat-label">METAL GPU</div>
+          <div class="stat-val">{{ currentModel.gpuUtil }}</div>
+          <div class="stat-bar-track"><div class="stat-bar-fill metal" :style="{ width: currentModel.gpuUtil }"></div></div>
+        </div>
+        <div class="hud-stat">
+          <div class="stat-label">MEMORY</div>
+          <div class="stat-val">{{ currentModel.ram }}</div>
+        </div>
+        <div class="hud-stat">
+          <div class="stat-label">SPEED</div>
+          <div class="stat-val highlight">{{ currentModel.speed }}</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="local-demo-screen">
+      <div class="screen-hud-bar">
+        <div class="hud-left">
+          <span class="hud-dot active"></span>
+          <span class="hud-model-tag">{{ currentModel.name }}</span>
+        </div>
+        <div class="hud-right">
+          <span class="hud-speed-badge">{{ currentModel.speed }}</span>
+        </div>
+      </div>
+
+      <div class="screen-chat-area">
+        <div class="chat-row user">
+          <div class="chat-bubble user">
+            运行端侧模型不需要网络连接吗？
+          </div>
+        </div>
+
+        <div class="chat-row bot">
+          <div class="chat-think-box">
+            <div class="think-header">
+              <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2">
+                <path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83" />
+              </svg>
+              <span>{{ text.localDemo?.thinkHeader || '本地模型思考时间线 (Thinking Timeline)' }}</span>
+            </div>
+            <div class="think-content">{{ currentModel.thinking }}</div>
+          </div>
+
+          <div class="chat-bubble bot">
+            {{ currentModel.response }}
+            <br /><br />
+            <strong>完全不需要网络！</strong>模型权重与 Embedding 嵌入向量数据库（SQLite）完全运行在你的设备本机。无需 API Key，零联网权限，不消耗任何数据流量。
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/docs/landing/src/components/LocalModelDemo.vue
+++ b/docs/landing/src/components/LocalModelDemo.vue
@@ -13,40 +13,43 @@ const metalOffload = ref(true);
 const flashAttention = ref(true);
 const kvCache = ref(true);
 
-const models = computed(() => [
-  {
+const localDemoText = computed(() => props.text.localDemo || {});
+
+const rawModels = computed(() => localDemoText.value.models || []);
+
+const currentModel = computed(() => {
+  const base = rawModels.value[selectedModelIndex.value] || rawModels.value[0] || {
     name: 'Qwen2.5-7B-Instruct.Q4_K_M.gguf',
     size: '4.35 GB',
-    ram: metalOffload.value ? '4.8 GB (Metal)' : '5.1 GB (RAM)',
-    gpuUtil: metalOffload.value ? '88%' : '0%',
-    cpuUtil: metalOffload.value ? '18%' : '76%',
-    speed: flashAttention.value ? '38.4 t/s' : '22.1 t/s',
-    thinking: '正在使用本地端侧权重视觉/逻辑推理，针对问答结构与格式进行编译处理...',
-    response: '根据离线知识库与 GRDB 本地索引，当前系统硬件加速正常启用。'
-  },
-  {
-    name: 'DeepSeek-R1-Distill-Q4_K_S.gguf',
-    size: '4.10 GB',
-    ram: metalOffload.value ? '4.5 GB (Metal)' : '4.8 GB (RAM)',
-    gpuUtil: metalOffload.value ? '94%' : '0%',
-    cpuUtil: metalOffload.value ? '12%' : '84%',
-    speed: flashAttention.value ? '42.8 t/s' : '26.5 t/s',
-    thinking: '分析思考链路：1. 检索本地 SQLite 数据库；2. 解析 GGUF Jinja Chat Template；3. 生成流式思考步骤与最终结论...',
-    response: 'DeepSeek-R1 本地推理完成！思考耗时 1.2 秒，全流式 Metal GPU 加速输出。'
-  },
-  {
-    name: 'Llama-3.1-8B-Instruct.Q4_K_M.gguf',
-    size: '4.92 GB',
-    ram: metalOffload.value ? '5.4 GB (Metal)' : '5.8 GB (RAM)',
-    gpuUtil: metalOffload.value ? '82%' : '0%',
-    cpuUtil: metalOffload.value ? '22%' : '68%',
-    speed: flashAttention.value ? '34.2 t/s' : '19.8 t/s',
-    thinking: 'Checking local GGUF memory budget and KV cache allocation...',
-    response: 'Llama 3.1 8B local execution complete. All memory and KV offload operating strictly within sandbox limits.'
-  }
-]);
+    thinking: '',
+    response: ''
+  };
 
-const currentModel = computed(() => models.value[selectedModelIndex.value]);
+  const isMetal = metalOffload.value;
+  const isFlash = flashAttention.value;
+  const isKV = kvCache.value;
+
+  // Calculate dynamic HUD stats based on hardware toggles including kvCache
+  let cpu = isMetal ? '18%' : '78%';
+  let gpu = isMetal ? '92%' : '0%';
+  let ram = isMetal
+    ? (isKV ? '4.2 GB (Metal)' : '4.8 GB (Metal)')
+    : (isKV ? '4.5 GB (RAM)' : '5.1 GB (RAM)');
+  let speedVal = isFlash
+    ? (isKV ? 42.6 : 38.4)
+    : (isKV ? 25.8 : 22.1);
+
+  return {
+    ...base,
+    ram,
+    gpuUtil: gpu,
+    cpuUtil: cpu,
+    speed: `${speedVal} t/s`,
+    kvStatusLabel: isKV
+      ? (localDemoText.value.kvCacheActiveLabel || 'KV Cache Reused')
+      : (localDemoText.value.kvCacheInactiveLabel || 'KV Cache Off')
+  };
+});
 </script>
 
 <template>
@@ -54,12 +57,12 @@ const currentModel = computed(() => models.value[selectedModelIndex.value]);
     <div class="local-demo-controls">
       <div class="control-header">
         <span class="control-badge">GGUF · llama.cpp C ABI</span>
-        <span class="control-title">{{ text.localDemo?.selectModelLabel || '选择本地 GGUF 模型' }}</span>
+        <span class="control-title">{{ localDemoText.selectModelLabel || 'Select Local GGUF Model' }}</span>
       </div>
 
       <div class="model-buttons">
         <button
-          v-for="(m, i) in models"
+          v-for="(m, i) in rawModels"
           :key="i"
           type="button"
           class="model-chip-btn"
@@ -87,7 +90,7 @@ const currentModel = computed(() => models.value[selectedModelIndex.value]);
         <label class="toggle-item">
           <input type="checkbox" v-model="kvCache" />
           <span class="toggle-box"></span>
-          <span class="toggle-text">KV Cache Offload</span>
+          <span class="toggle-text">KV Cache Prefix Reuse</span>
         </label>
       </div>
 
@@ -121,6 +124,7 @@ const currentModel = computed(() => models.value[selectedModelIndex.value]);
           <span class="hud-model-tag">{{ currentModel.name }}</span>
         </div>
         <div class="hud-right">
+          <span class="hud-kv-tag" :class="{ active: kvCache }">{{ currentModel.kvStatusLabel }}</span>
           <span class="hud-speed-badge">{{ currentModel.speed }}</span>
         </div>
       </div>
@@ -128,25 +132,23 @@ const currentModel = computed(() => models.value[selectedModelIndex.value]);
       <div class="screen-chat-area">
         <div class="chat-row user">
           <div class="chat-bubble user">
-            运行端侧模型不需要网络连接吗？
+            {{ localDemoText.userQuestion }}
           </div>
         </div>
 
         <div class="chat-row bot">
-          <div class="chat-think-box">
+          <div v-if="currentModel.thinking" class="chat-think-box">
             <div class="think-header">
               <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2">
                 <path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83" />
               </svg>
-              <span>{{ text.localDemo?.thinkHeader || '本地模型思考时间线 (Thinking Timeline)' }}</span>
+              <span>{{ localDemoText.thinkHeader || 'Thinking Timeline' }}</span>
             </div>
             <div class="think-content">{{ currentModel.thinking }}</div>
           </div>
 
           <div class="chat-bubble bot">
             {{ currentModel.response }}
-            <br /><br />
-            <strong>完全不需要网络！</strong>模型权重与 Embedding 嵌入向量数据库（SQLite）完全运行在你的设备本机。无需 API Key，零联网权限，不消耗任何数据流量。
           </div>
         </div>
       </div>

--- a/docs/landing/src/components/McpSkillsDemo.vue
+++ b/docs/landing/src/components/McpSkillsDemo.vue
@@ -1,0 +1,106 @@
+<script setup>
+import { ref, computed } from 'vue';
+
+const props = defineProps({
+  text: {
+    type: Object,
+    required: true
+  }
+});
+
+const activeTab = ref('mcp'); // 'mcp', 'skills', 'js', 'rag'
+
+const items = computed(() => [
+  {
+    id: 'mcp',
+    type: 'MCP SERVER',
+    title: 'HealthKit & Calendar MCP',
+    badge: 'Official Swift MCP SDK',
+    desc: '在 AI 想要获取你的步数或日历日程时，原生交互 Sheet 会向你申请权限，绝不静默窃取隐私。',
+    snippet: `// Native MCP Tool Execution
+{
+  "server": "etos.mcp.personal",
+  "tool": "get_daily_steps",
+  "arguments": { "date": "today" },
+  "approval": "ASK_USER_CONFIRMATION"
+}`
+  },
+  {
+    id: 'skills',
+    type: 'AGENT SKILLS',
+    title: 'GitHub 技能包一键导入',
+    badge: 'Agentic Skill Pack',
+    desc: '直接粘贴 GitHub 仓库链接或 RAW 文件地址，即刻注入代码审查、海报生成或工作流指令集。',
+    snippet: `# SKILL: CodeReviewer Pro
+description: "Inspect Swift & Rust diffs for memory leaks"
+tools: [file_search, git_diff_parser]
+instructions: |
+  Check for strong reference cycles in closure capture lists.`
+  },
+  {
+    id: 'js',
+    type: 'CUSTOM JS',
+    title: '沙盒 JavaScript 自定义工具',
+    badge: 'Isolated JS Engine',
+    desc: '在手机上直接编辑与运行轻量 JS 脚本工具，无死锁执行，与系统沙盒完美隔离。',
+    snippet: `// CustomJSTools/weather.js
+export async function run(args) {
+  const res = await fetch(\`https://api.weather.com/\${args.city}\`);
+  return res.json();
+}`
+  },
+  {
+    id: 'rag',
+    type: 'SQLCIPHER RAG',
+    title: 'SQLite 全盘物理加密向量库',
+    badge: 'GRDB + SQLCipher',
+    desc: '本地 Embedding 与长效记忆直接落地在加密 SQLite 数据库中，支持 SillyTavern 世界书触发。',
+    snippet: `CREATE TABLE memory_vectors (
+  id TEXT PRIMARY KEY,
+  vector BLOB NOT NULL,
+  content TEXT NOT NULL,
+  created_at INTEGER NOT NULL
+) STRICT;`
+  }
+]);
+
+const currentItem = computed(() => items.value.find(i => i.id === activeTab.value) || items.value[0]);
+</script>
+
+<template>
+  <div class="mcp-demo-container">
+    <div class="mcp-tabs">
+      <button
+        v-for="item in items"
+        :key="item.id"
+        type="button"
+        class="mcp-tab-btn"
+        :class="{ active: activeTab === item.id }"
+        @click="activeTab = item.id"
+      >
+        <span class="tab-type">{{ item.type }}</span>
+        <span class="tab-title">{{ item.title }}</span>
+      </button>
+    </div>
+
+    <div class="mcp-display-card">
+      <div class="mcp-card-header">
+        <div class="mcp-card-meta">
+          <span class="mcp-badge">{{ currentItem.badge }}</span>
+          <h3>{{ currentItem.title }}</h3>
+        </div>
+        <p class="mcp-desc">{{ currentItem.desc }}</p>
+      </div>
+
+      <div class="mcp-code-preview">
+        <div class="code-bar">
+          <span class="dot red"></span>
+          <span class="dot yellow"></span>
+          <span class="dot green"></span>
+          <span class="code-filename">{{ currentItem.id.toUpperCase() }} SPEC</span>
+        </div>
+        <pre><code>{{ currentItem.snippet }}</code></pre>
+      </div>
+    </div>
+  </div>
+</template>

--- a/docs/landing/src/components/McpSkillsDemo.vue
+++ b/docs/landing/src/components/McpSkillsDemo.vue
@@ -34,6 +34,7 @@ const currentTabItem = computed(() => {
         type="button"
         class="mcp-tab-btn"
         :class="{ active: activeTab === item.id }"
+        :aria-pressed="activeTab === item.id"
         @click="activeTab = item.id"
       >
         <span class="tab-type">{{ item.type }}</span>
@@ -55,7 +56,7 @@ const currentTabItem = computed(() => {
           <span class="dot red"></span>
           <span class="dot yellow"></span>
           <span class="dot green"></span>
-          <span class="code-filename">{{ currentTabItem.id.toUpperCase() }} SPEC</span>
+          <span class="code-filename">{{ currentTabItem.id.toUpperCase() }} {{ sectionText.specLabel }}</span>
         </div>
         <pre><code>{{ currentTabItem.snippet }}</code></pre>
       </div>

--- a/docs/landing/src/components/McpSkillsDemo.vue
+++ b/docs/landing/src/components/McpSkillsDemo.vue
@@ -8,70 +8,28 @@ const props = defineProps({
   }
 });
 
-const activeTab = ref('mcp'); // 'mcp', 'skills', 'js', 'rag'
+const activeTab = ref('mcp');
 
-const items = computed(() => [
-  {
+const sectionText = computed(() => props.text.mcpSkillsSection || {});
+const tabs = computed(() => sectionText.value.tabs || []);
+
+const currentTabItem = computed(() => {
+  return tabs.value.find(t => t.id === activeTab.value) || tabs.value[0] || {
     id: 'mcp',
     type: 'MCP SERVER',
-    title: 'HealthKit & Calendar MCP',
-    badge: 'Official Swift MCP SDK',
-    desc: '在 AI 想要获取你的步数或日历日程时，原生交互 Sheet 会向你申请权限，绝不静默窃取隐私。',
-    snippet: `// Native MCP Tool Execution
-{
-  "server": "etos.mcp.personal",
-  "tool": "get_daily_steps",
-  "arguments": { "date": "today" },
-  "approval": "ASK_USER_CONFIRMATION"
-}`
-  },
-  {
-    id: 'skills',
-    type: 'AGENT SKILLS',
-    title: 'GitHub 技能包一键导入',
-    badge: 'Agentic Skill Pack',
-    desc: '直接粘贴 GitHub 仓库链接或 RAW 文件地址，即刻注入代码审查、海报生成或工作流指令集。',
-    snippet: `# SKILL: CodeReviewer Pro
-description: "Inspect Swift & Rust diffs for memory leaks"
-tools: [file_search, git_diff_parser]
-instructions: |
-  Check for strong reference cycles in closure capture lists.`
-  },
-  {
-    id: 'js',
-    type: 'CUSTOM JS',
-    title: '沙盒 JavaScript 自定义工具',
-    badge: 'Isolated JS Engine',
-    desc: '在手机上直接编辑与运行轻量 JS 脚本工具，无死锁执行，与系统沙盒完美隔离。',
-    snippet: `// CustomJSTools/weather.js
-export async function run(args) {
-  const res = await fetch(\`https://api.weather.com/\${args.city}\`);
-  return res.json();
-}`
-  },
-  {
-    id: 'rag',
-    type: 'SQLCIPHER RAG',
-    title: 'SQLite 全盘物理加密向量库',
-    badge: 'GRDB + SQLCipher',
-    desc: '本地 Embedding 与长效记忆直接落地在加密 SQLite 数据库中，支持 SillyTavern 世界书触发。',
-    snippet: `CREATE TABLE memory_vectors (
-  id TEXT PRIMARY KEY,
-  vector BLOB NOT NULL,
-  content TEXT NOT NULL,
-  created_at INTEGER NOT NULL
-) STRICT;`
-  }
-]);
-
-const currentItem = computed(() => items.value.find(i => i.id === activeTab.value) || items.value[0]);
+    title: '',
+    badge: '',
+    desc: '',
+    snippet: ''
+  };
+});
 </script>
 
 <template>
   <div class="mcp-demo-container">
     <div class="mcp-tabs">
       <button
-        v-for="item in items"
+        v-for="item in tabs"
         :key="item.id"
         type="button"
         class="mcp-tab-btn"
@@ -86,10 +44,10 @@ const currentItem = computed(() => items.value.find(i => i.id === activeTab.valu
     <div class="mcp-display-card">
       <div class="mcp-card-header">
         <div class="mcp-card-meta">
-          <span class="mcp-badge">{{ currentItem.badge }}</span>
-          <h3>{{ currentItem.title }}</h3>
+          <span class="mcp-badge">{{ currentTabItem.badge }}</span>
+          <h3>{{ currentTabItem.title }}</h3>
         </div>
-        <p class="mcp-desc">{{ currentItem.desc }}</p>
+        <p class="mcp-desc">{{ currentTabItem.desc }}</p>
       </div>
 
       <div class="mcp-code-preview">
@@ -97,9 +55,9 @@ const currentItem = computed(() => items.value.find(i => i.id === activeTab.valu
           <span class="dot red"></span>
           <span class="dot yellow"></span>
           <span class="dot green"></span>
-          <span class="code-filename">{{ currentItem.id.toUpperCase() }} SPEC</span>
+          <span class="code-filename">{{ currentTabItem.id.toUpperCase() }} SPEC</span>
         </div>
-        <pre><code>{{ currentItem.snippet }}</code></pre>
+        <pre><code>{{ currentTabItem.snippet }}</code></pre>
       </div>
     </div>
   </div>

--- a/docs/landing/src/composables/useContextCursor.js
+++ b/docs/landing/src/composables/useContextCursor.js
@@ -1,18 +1,12 @@
 // ============================================================================
-// Context Cursor —— iPadOS 风格的「磁吸」指针
+// Context Cursor —— iPadOS 风格的「磁吸」指针 (超低延迟优化版)
 // ============================================================================
-// 一颗半透明玻璃圆点跟随鼠标；悬停到可交互元素（链接 / 按钮）上时，会变形成
-// 贴合该元素的圆角矩形并带轻微视差，营造 iPadOS 指针那种吸附 / 软糖质感。
+// 一颗半透明玻璃圆点跟随鼠标；悬停到可交互元素（链接 / 按钮）上时，会快速变形成
+// 贴合该元素的圆角矩形。
 //
-// 算法改编自 Marcel Wiethan 的 "context-cursor"（MIT，2020），
-// 经由 GoldenGoCoding 的 iPadOS 项目引入：
-//   原作者 / 致谢：Marcel Wiethan — context-cursor (MIT, 2020)
-//   参考项目：https://github.com/GoldenGoCoding/iPadOS
-//
-// 原版依赖 GSAP TweenLite，并以 [data-ccursor] 属性 + window.onload 收集目标。
-// 这里去掉 GSAP 依赖：尺寸/圆角用 CSS 过渡、位置用 requestAnimationFrame 插值，
-// 目标元素改为事件委托（无需改模板）。仅在 (pointer: fine) 且未开启
-// prefers-reduced-motion 的设备启用，触屏 / 无障碍场景自动跳过。
+// 性能与延迟优化：
+// 1. 自由移动模式下：位置 1:1 实时跟随鼠标，0ms 拖尾与迟钝感。
+// 2. 磁吸吸附模式下：采用 0.45 高响应度插值 + 0.12s 极速 CSS 变形。
 // ============================================================================
 
 const STYLE = `
@@ -23,24 +17,28 @@ const STYLE = `
   width: 18px;
   height: 18px;
   border-radius: 50%;
-  background: rgba(150, 150, 160, 0.18);
-  border: 1px solid rgba(255, 255, 255, 0.4);
+  background: rgba(150, 150, 160, 0.22);
+  border: 1px solid rgba(255, 255, 255, 0.45);
   box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
   pointer-events: none;
   z-index: 9999;
   opacity: 0;
   transform: translate3d(-100px, -100px, 0);
-  transition: width 0.22s cubic-bezier(0.22, 1, 0.36, 1),
-              height 0.22s cubic-bezier(0.22, 1, 0.36, 1),
-              border-radius 0.22s cubic-bezier(0.22, 1, 0.36, 1),
-              background-color 0.22s ease,
-              border-color 0.22s ease,
-              opacity 0.2s ease;
+  transition: width 0.12s cubic-bezier(0.16, 1, 0.3, 1),
+              height 0.12s cubic-bezier(0.16, 1, 0.3, 1),
+              border-radius 0.12s cubic-bezier(0.16, 1, 0.3, 1),
+              background-color 0.15s ease,
+              border-color 0.15s ease,
+              opacity 0.15s ease;
   will-change: transform, width, height;
 }
+.dark .cc-cursor {
+  background: rgba(255, 255, 255, 0.15);
+  border-color: rgba(255, 255, 255, 0.25);
+}
 .cc-cursor--active {
-  background: rgba(120, 120, 130, 0.14);
-  border-color: rgba(255, 255, 255, 0.5);
+  background: rgba(120, 120, 130, 0.16);
+  border-color: rgba(255, 255, 255, 0.6);
 }
 html.cc-enabled, html.cc-enabled * { cursor: none !important; }
 `;
@@ -53,13 +51,12 @@ export function initContextCursor(options = {}) {
 
   const SELECTOR =
     options.selector ||
-    'a[href], button, [role="button"], .btn-pill, .nav-link, .lang-btn, .theme-toggle';
-  const BASE = options.size || 18; // 自由态直径
-  const PAD = options.padding ?? 6; // 悬停时在元素四周外扩
-  const EASE = options.ease ?? 0.18; // 位置插值系数（越小越「拖尾」）
-  const PARALLAX = options.parallax ?? 6; // 悬停时光标朝鼠标偏移的分母（越大越轻）
+    'a[href], button, [role="button"], .btn-pill, .nav-link, .lang-btn, .theme-toggle, .model-chip-btn, .mcp-tab-btn';
+  const BASE = options.size || 18;
+  const PAD = options.padding ?? 6;
+  const EASE = options.ease ?? 0.45; // 吸附态高响应度插值
+  const PARALLAX = options.parallax ?? 8;
 
-  // 注入样式（一次）
   const styleEl = document.createElement('style');
   styleEl.textContent = STYLE;
   document.head.appendChild(styleEl);
@@ -96,20 +93,21 @@ export function initContextCursor(options = {}) {
   }
 
   function tick() {
-    // 目标可能被移除（如语言菜单收起）
     if (target && !target.isConnected) applyTarget(null);
 
-    let destX = mouseX;
-    let destY = mouseY;
     if (target) {
       const rect = target.getBoundingClientRect();
       const cx = rect.left + rect.width / 2;
       const cy = rect.top + rect.height / 2;
-      destX = cx + (mouseX - cx) / PARALLAX;
-      destY = cy + (mouseY - cy) / PARALLAX;
+      const destX = cx + (mouseX - cx) / PARALLAX;
+      const destY = cy + (mouseY - cy) / PARALLAX;
+      curX += (destX - curX) * EASE;
+      curY += (destY - curY) * EASE;
+    } else {
+      // 自由移动模式：100% 实时同步，0ms 拖尾
+      curX = mouseX;
+      curY = mouseY;
     }
-    curX += (destX - curX) * EASE;
-    curY += (destY - curY) * EASE;
 
     const w = blob.offsetWidth || BASE;
     const h = blob.offsetHeight || BASE;
@@ -124,13 +122,12 @@ export function initContextCursor(options = {}) {
       shown = true;
       blob.style.opacity = '1';
     }
-  });
+  }, { passive: true });
 
-  // 事件委托：进入任意元素时，向上找最近的可交互祖先
   document.addEventListener('mouseover', (e) => {
     const el = e.target.closest ? e.target.closest(SELECTOR) : null;
     applyTarget(el);
-  });
+  }, { passive: true });
 
   document.addEventListener('mouseleave', () => {
     blob.style.opacity = '0';

--- a/docs/landing/src/i18n.js
+++ b/docs/landing/src/i18n.js
@@ -49,12 +49,93 @@ const zh = {
     title: 'iOS 端侧硬核 GGUF 本地模型推理',
     lead: '不需要连接任何网络或 API 服务。底层通过 llama.cpp C ABI 桥接，直接在 iPhone 上加载 GGUF 权重，并提供实时 CPU / Metal / 内存性能监视器。',
     selectModelLabel: '选择本地 GGUF 模型',
-    thinkHeader: '本地模型思考时间线 (Thinking Timeline)'
+    thinkHeader: '本地模型思考时间线 (Thinking Timeline)',
+    userQuestion: '运行端侧 GGUF 本地模型需要连接网络或 API Key 吗？',
+    kvCacheActiveLabel: 'KV Cache 前缀复用已生效',
+    kvCacheInactiveLabel: 'KV Cache 未开启',
+    models: [
+      {
+        name: 'Qwen2.5-7B-Instruct.Q4_K_M.gguf',
+        size: '4.35 GB',
+        thinking: '正在使用 Metal GPU 加速计算，分析对话上下文与 GGUF Jinja 对话模板...',
+        response: '完全不需要网络或 API Key！模型权重与 Embedding 嵌入向量数据库完全运行在你的 iPhone 本机设备上。零联网权限，不消耗流量，隐私 100% 物理隔离。'
+      },
+      {
+        name: 'DeepSeek-R1-Distill-Llama-8B.Q4_K_M.gguf',
+        size: '4.92 GB',
+        thinking: '正在解析 <think> 推理链：1. 检索本地 SQLite 数据库；2. 匹配 KV Cache 缓存前缀；3. 生成结构化思考步骤...',
+        response: 'DeepSeek-R1 本地推理完成！思考耗时 1.2 秒，全流式 Metal GPU 加速输出与 KV Cache 前缀复用正常。'
+      },
+      {
+        name: 'Gemma-2-9B-Instruct.Q4_K_M.gguf',
+        size: '5.42 GB',
+        thinking: 'Checking local GGUF memory budget and Metal GPU offload layers...',
+        response: 'Gemma 2 9B local execution complete. All memory and KV offload operating strictly within iOS sandbox limits.'
+      }
+    ]
   },
   mcpSkillsSection: {
     badge: '工具与生态',
     title: 'MCP 协议 · Agent Skills · 沙盒 JS',
-    lead: '集成 Swift Model Context Protocol (MCP) 官方 SDK，支持从 GitHub 一键导入 Agent Skills 技能包，并可在沙盒内运行自定义 JavaScript 工具。'
+    lead: '集成 Swift Model Context Protocol (MCP) 官方 SDK，支持从 GitHub 一键导入 Agent Skills 技能包，并可在沙盒内运行自定义 JavaScript 工具。',
+    tabs: [
+      {
+        id: 'mcp',
+        type: 'MCP SERVER',
+        title: 'Built-in App Tool MCP',
+        badge: 'Official Swift MCP SDK',
+        desc: '在 AI 想要获取设备时间或查询沙盒时，统一通过内建 MCP 服务器调度，且支持原生问答 Sheet 审批策略。',
+        snippet: `// Built-in App Tool MCP Execution
+{
+  "server": "etos_builtin_app_tool",
+  "tool": "app_get_system_time",
+  "arguments": { "timezone": "Asia/Shanghai" },
+  "approval": "ASK_USER_CONFIRMATION"
+}`
+      },
+      {
+        id: 'skills',
+        type: 'AGENT SKILLS',
+        title: 'GitHub 技能包一键导入',
+        badge: 'Agentic Skill Pack',
+        desc: '直接粘贴 GitHub 仓库链接或 RAW 文件地址，即刻注入代码审查、海报生成或工作流指令集。',
+        snippet: `# SKILL: CodeReviewer Pro
+description: "Inspect Swift & Rust diffs for memory leaks"
+tools: [app_read_sandbox_file, app_query_sqlite]
+instructions: |
+  Check for strong reference cycles in closure capture lists.`
+      },
+      {
+        id: 'jsc',
+        type: 'JSC JS TOOL',
+        title: 'JavaScriptCore 格式化工具',
+        badge: 'app_create_custom_jsc_js_tool',
+        desc: '创建可复用的 iOS JSC 自定义脚本工具，脚本声明同步 function main(input)，保存在 CustomJSTools 目录。',
+        snippet: `// CustomJSTools/format_currency.js
+// iOS JSC 执行引擎：同步函数，无 Node/fetch/Promise
+function main(input) {
+  var amount = input.amount || 0;
+  var currency = input.currency || 'USD';
+  return {
+    formatted: currency + ' ' + amount.toFixed(2),
+    timestamp: new Date().toISOString()
+  };
+}`
+      },
+      {
+        id: 'rag',
+        type: 'SQLCIPHER RAG',
+        title: 'SQLite 全盘物理加密向量库',
+        badge: 'GRDB + SQLCipher',
+        desc: '本地 Embedding 与长效记忆直接落地在加密 SQLite 数据库中，支持 SillyTavern 世界书触发。',
+        snippet: `CREATE TABLE memory_vectors (
+  id TEXT PRIMARY KEY,
+  vector BLOB NOT NULL,
+  content TEXT NOT NULL,
+  created_at INTEGER NOT NULL
+) STRICT;`
+      }
+    ]
   },
   personalize: {
     title: '一眼认得出，是你的 Studio。',
@@ -225,12 +306,93 @@ const en = {
     title: 'Native GGUF Inference & Performance HUD on iOS',
     lead: 'No network or API keys needed. Bridged via llama.cpp C ABI directly on iOS with Metal GPU acceleration and real-time CPU / Metal / Memory telemetry.',
     selectModelLabel: 'Select Local GGUF Model',
-    thinkHeader: 'Thinking Timeline'
+    thinkHeader: 'Thinking Timeline',
+    userQuestion: 'Does running on-device GGUF models require network or API keys?',
+    kvCacheActiveLabel: 'KV Cache Prefix Reuse Active',
+    kvCacheInactiveLabel: 'KV Cache Disabled',
+    models: [
+      {
+        name: 'Qwen2.5-7B-Instruct.Q4_K_M.gguf',
+        size: '4.35 GB',
+        thinking: 'Accelerating via Metal GPU, analyzing chat context and GGUF Jinja chat template...',
+        response: 'No network or API key required! Model weights and SQLite vector database run 100% locally on your iPhone with zero telemetry.'
+      },
+      {
+        name: 'DeepSeek-R1-Distill-Llama-8B.Q4_K_M.gguf',
+        size: '4.92 GB',
+        thinking: 'Parsing <think> reasoning chain: 1. Search local SQLite; 2. Match KV Cache prefix; 3. Generate structured thinking steps...',
+        response: 'DeepSeek-R1 local inference complete! Reasoning duration 1.2s with full Metal GPU acceleration and KV Cache prefix reuse.'
+      },
+      {
+        name: 'Gemma-2-9B-Instruct.Q4_K_M.gguf',
+        size: '5.42 GB',
+        thinking: 'Checking local GGUF memory budget and Metal GPU offload layers...',
+        response: 'Gemma 2 9B local execution complete. All memory and KV offload operating strictly within iOS sandbox limits.'
+      }
+    ]
   },
   mcpSkillsSection: {
     badge: 'Tools & Ecosystem',
     title: 'MCP Protocol · Agent Skills · Sandboxed JS',
     lead: 'Official Swift Model Context Protocol SDK, one-click Agent Skill import from GitHub, and sandboxed JavaScript tool runtime.',
+    tabs: [
+      {
+        id: 'mcp',
+        type: 'MCP SERVER',
+        title: 'Built-in App Tool MCP',
+        badge: 'Official Swift MCP SDK',
+        desc: 'When AI requests system time or sandbox access, requests route through the built-in MCP server with native approval Sheet controls.',
+        snippet: `// Built-in App Tool MCP Execution
+{
+  "server": "etos_builtin_app_tool",
+  "tool": "app_get_system_time",
+  "arguments": { "timezone": "America/New_York" },
+  "approval": "ASK_USER_CONFIRMATION"
+}`
+      },
+      {
+        id: 'skills',
+        type: 'AGENT SKILLS',
+        title: 'GitHub Skill Import',
+        badge: 'Agentic Skill Pack',
+        desc: 'Paste GitHub repo links or RAW file URLs to inject code inspection or prompt workflow skill packs.',
+        snippet: `# SKILL: CodeReviewer Pro
+description: "Inspect Swift & Rust diffs for memory leaks"
+tools: [app_read_sandbox_file, app_query_sqlite]
+instructions: |
+  Check for strong reference cycles in closure capture lists.`
+      },
+      {
+        id: 'jsc',
+        type: 'JSC JS TOOL',
+        title: 'JavaScriptCore Formatter',
+        badge: 'app_create_custom_jsc_js_tool',
+        desc: 'Create reusable iOS JSC custom script tools with synchronous main(input) functions saved in CustomJSTools.',
+        snippet: `// CustomJSTools/format_currency.js
+// iOS JSC Execution Engine: Sync function without Node/fetch/Promise
+function main(input) {
+  var amount = input.amount || 0;
+  var currency = input.currency || 'USD';
+  return {
+    formatted: currency + ' ' + amount.toFixed(2),
+    timestamp: new Date().toISOString()
+  };
+}`
+      },
+      {
+        id: 'rag',
+        type: 'SQLCIPHER RAG',
+        title: 'SQLite Encrypted Vector Store',
+        badge: 'GRDB + SQLCipher',
+        desc: 'Local embeddings and long-term memory stored inside encrypted SQLite database with SillyTavern Worldbook support.',
+        snippet: `CREATE TABLE memory_vectors (
+  id TEXT PRIMARY KEY,
+  vector BLOB NOT NULL,
+  content TEXT NOT NULL,
+  created_at INTEGER NOT NULL
+) STRICT;`
+      }
+    ]
   },
   personalize: {
     title: 'Unmistakably yours.',
@@ -401,12 +563,93 @@ const ja = {
     title: 'iOS 上での GGUF 推論 & パフォーマンス HUD',
     lead: 'ネット接続や API キーは一切不要。llama.cpp C ABI 経由で Metal GPU アクセラレーションとリアルタイム CPU/GPU/メモリ モニターを搭載。',
     selectModelLabel: 'ローカル GGUF モデルを選択',
-    thinkHeader: '思考タイムライン (Thinking Timeline)'
+    thinkHeader: '思考タイムライン (Thinking Timeline)',
+    userQuestion: 'ローカル GGUF モデルの実行にネット接続や API キーは必要ですか？',
+    kvCacheActiveLabel: 'KV Cache プレフィックス再利用中',
+    kvCacheInactiveLabel: 'KV Cache 未有効化',
+    models: [
+      {
+        name: 'Qwen2.5-7B-Instruct.Q4_K_M.gguf',
+        size: '4.35 GB',
+        thinking: 'Metal GPU 加速で計算中、GGUF Jinja テンプレートを解析中...',
+        response: 'ネット接続や API キーは一切不要です！モデルウェイトと SQLite ベクトル DB は端末内で 100% ローカル動作します。'
+      },
+      {
+        name: 'DeepSeek-R1-Distill-Llama-8B.Q4_K_M.gguf',
+        size: '4.92 GB',
+        thinking: '<think> 推論チェーンを解析中: 1. SQLite 検索; 2. KV Cache マッチング; 3. 思考ステップ生成...',
+        response: 'DeepSeek-R1 ローカル推論完了！思考時間 1.2 秒、Metal GPU 加速と KV Cache 再利用が正常に動作しています。'
+      },
+      {
+        name: 'Gemma-2-9B-Instruct.Q4_K_M.gguf',
+        size: '5.42 GB',
+        thinking: 'Checking local GGUF memory budget and Metal GPU offload layers...',
+        response: 'Gemma 2 9B local execution complete. All memory and KV offload operating strictly within iOS sandbox limits.'
+      }
+    ]
   },
   mcpSkillsSection: {
     badge: 'ツールとエコシステム',
     title: 'MCP プロトコル · Agent Skills · Sandboxed JS',
-    lead: '公式 Swift MCP SDK、GitHub からのワンクリック Agent Skill インポート、サンドボックス化 JavaScript ランタイムを搭載。'
+    lead: '公式 Swift MCP SDK、GitHub からのワンクリック Agent Skill インポート、サンドボックス化 JavaScript ランタイムを搭載。',
+    tabs: [
+      {
+        id: 'mcp',
+        type: 'MCP SERVER',
+        title: 'Built-in App Tool MCP',
+        badge: 'Official Swift MCP SDK',
+        desc: 'システム時間やサンドボックスアクセスの要求は、組み込み MCP サーバーとネイティブ承認 Sheet 経由で安全に処理されます。',
+        snippet: `// Built-in App Tool MCP Execution
+{
+  "server": "etos_builtin_app_tool",
+  "tool": "app_get_system_time",
+  "arguments": { "timezone": "Asia/Tokyo" },
+  "approval": "ASK_USER_CONFIRMATION"
+}`
+      },
+      {
+        id: 'skills',
+        type: 'AGENT SKILLS',
+        title: 'GitHub スキルインポート',
+        badge: 'Agentic Skill Pack',
+        desc: 'GitHub リポジトリリンクや RAW URL を貼り付けるだけで、コードレビューやワークフロースキルを注入。',
+        snippet: `# SKILL: CodeReviewer Pro
+description: "Inspect Swift & Rust diffs for memory leaks"
+tools: [app_read_sandbox_file, app_query_sqlite]
+instructions: |
+  Check for strong reference cycles in closure capture lists.`
+      },
+      {
+        id: 'jsc',
+        type: 'JSC JS TOOL',
+        title: 'JavaScriptCore フォーマッター',
+        badge: 'app_create_custom_jsc_js_tool',
+        desc: 'CustomJSTools に保存される同期 function main(input) を備えた再利用可能な iOS JSC カスタムスクリプト。',
+        snippet: `// CustomJSTools/format_currency.js
+// iOS JSC エンジン: Node/fetch/Promise なしの同期関数
+function main(input) {
+  var amount = input.amount || 0;
+  var currency = input.currency || 'USD';
+  return {
+    formatted: currency + ' ' + amount.toFixed(2),
+    timestamp: new Date().toISOString()
+  };
+}`
+      },
+      {
+        id: 'rag',
+        type: 'SQLCIPHER RAG',
+        title: 'SQLite 暗号化ベクトルストア',
+        badge: 'GRDB + SQLCipher',
+        desc: '暗号化 SQLite データベース内に長期記憶を保存。SillyTavern ワールドブック対応。',
+        snippet: `CREATE TABLE memory_vectors (
+  id TEXT PRIMARY KEY,
+  vector BLOB NOT NULL,
+  content TEXT NOT NULL,
+  created_at INTEGER NOT NULL
+) STRICT;`
+      }
+    ]
   },
   personalize: {
     title: 'あなただけの Studio。',
@@ -568,12 +811,93 @@ const ru = {
     title: 'Нативный GGUF инференс и HUD производительности на iOS',
     lead: 'Работает полностью без интернета. Модели GGUF исполняются через C ABI llama.cpp с ускорением Metal GPU и онлайн-монитором CPU/Metal/Памяти.',
     selectModelLabel: 'Выберите модель GGUF',
-    thinkHeader: 'Таймлайн размышлений (Thinking Timeline)'
+    thinkHeader: 'Таймлайн размышлений (Thinking Timeline)',
+    userQuestion: 'Требуется ли интернет или API ключ для локальной модели GGUF?',
+    kvCacheActiveLabel: 'Префикс KV Cache активирован',
+    kvCacheInactiveLabel: 'KV Cache отключен',
+    models: [
+      {
+        name: 'Qwen2.5-7B-Instruct.Q4_K_M.gguf',
+        size: '4.35 GB',
+        thinking: 'Ускорение Metal GPU, анализ контекста чата и шаблона GGUF Jinja...',
+        response: 'Интернет и API ключ не требуются! Веса модели и векторная база SQLite работают 100% локально на вашем iPhone.'
+      },
+      {
+        name: 'DeepSeek-R1-Distill-Llama-8B.Q4_K_M.gguf',
+        size: '4.92 GB',
+        thinking: 'Разбор цепочки <think>: 1. Поиск SQLite; 2. Совпадение KV Cache; 3. Генерация шагов...',
+        response: 'Локальный инференс DeepSeek-R1 завершен! Время размышления 1.2с с ускорением Metal GPU.'
+      },
+      {
+        name: 'Gemma-2-9B-Instruct.Q4_K_M.gguf',
+        size: '5.42 GB',
+        thinking: 'Checking local GGUF memory budget and Metal GPU offload layers...',
+        response: 'Gemma 2 9B local execution complete. All memory and KV offload operating strictly within iOS sandbox limits.'
+      }
+    ]
   },
   mcpSkillsSection: {
     badge: 'Инструменты и экосистема',
     title: 'Протокол MCP · Agent Skills · Песочница JS',
     lead: 'Официальный Swift MCP SDK, импорт Agent Skills с GitHub в один клик и изолированный запуск JS-скриптов.',
+    tabs: [
+      {
+        id: 'mcp',
+        type: 'MCP SERVER',
+        title: 'Built-in App Tool MCP',
+        badge: 'Official Swift MCP SDK',
+        desc: 'Запросы к системному времени или песочнице направляются через встроенный MCP сервер с нативным подтверждением.',
+        snippet: `// Built-in App Tool MCP Execution
+{
+  "server": "etos_builtin_app_tool",
+  "tool": "app_get_system_time",
+  "arguments": { "timezone": "Europe/Moscow" },
+  "approval": "ASK_USER_CONFIRMATION"
+}`
+      },
+      {
+        id: 'skills',
+        type: 'AGENT SKILLS',
+        title: 'Импорт навыков GitHub',
+        badge: 'Agentic Skill Pack',
+        desc: 'Вставьте ссылку на GitHub или RAW URL для внедрения пакетов навыков ревью кода и рабочих процессов.',
+        snippet: `# SKILL: CodeReviewer Pro
+description: "Inspect Swift & Rust diffs for memory leaks"
+tools: [app_read_sandbox_file, app_query_sqlite]
+instructions: |
+  Check for strong reference cycles in closure capture lists.`
+      },
+      {
+        id: 'jsc',
+        type: 'JSC JS TOOL',
+        title: 'Форматирование JavaScriptCore',
+        badge: 'app_create_custom_jsc_js_tool',
+        desc: 'Создавайте многоразовые инструменты JS с синхронной функцией main(input), сохраняемые в CustomJSTools.',
+        snippet: `// CustomJSTools/format_currency.js
+// Движок iOS JSC: Синхронная функция без Node/fetch/Promise
+function main(input) {
+  var amount = input.amount || 0;
+  var currency = input.currency || 'USD';
+  return {
+    formatted: currency + ' ' + amount.toFixed(2),
+    timestamp: new Date().toISOString()
+  };
+}`
+      },
+      {
+        id: 'rag',
+        type: 'SQLCIPHER RAG',
+        title: 'Зашифрованная база SQLite RAG',
+        badge: 'GRDB + SQLCipher',
+        desc: 'Долгосрочная память сохраняется в зашифрованной базе SQLite с поддержкой SillyTavern Worldbook.',
+        snippet: `CREATE TABLE memory_vectors (
+  id TEXT PRIMARY KEY,
+  vector BLOB NOT NULL,
+  content TEXT NOT NULL,
+  created_at INTEGER NOT NULL
+) STRICT;`
+      }
+    ]
   },
   personalize: {
     title: 'Ваш уникальный Studio.',
@@ -735,12 +1059,93 @@ const zhHant = {
     title: 'iOS 端側硬核 GGUF 本地模型推理',
     lead: '不需要連接任何網路或 API 服務。底層通過 llama.cpp C ABI 橋接，直接在 iPhone 上加載 GGUF 權重，並提供實時 CPU / Metal / 記憶體性能監視器。',
     selectModelLabel: '選擇本地 GGUF 模型',
-    thinkHeader: '本地模型思考時間線 (Thinking Timeline)'
+    thinkHeader: '本地模型思考時間線 (Thinking Timeline)',
+    userQuestion: '運行端側 GGUF 本地模型需要連接網路或 API Key 嗎？',
+    kvCacheActiveLabel: 'KV Cache 前綴複用已生效',
+    kvCacheInactiveLabel: 'KV Cache 未開啟',
+    models: [
+      {
+        name: 'Qwen2.5-7B-Instruct.Q4_K_M.gguf',
+        size: '4.35 GB',
+        thinking: '正在使用 Metal GPU 加速計算，分析對話上下文與 GGUF Jinja 對話模板...',
+        response: '完全不需要網路或 API Key！模型權重與 Embedding 嵌入向量數據庫完全運行在你的 iPhone 本機設備上。零聯網權限，不消耗流量，隱私 100% 物理隔離。'
+      },
+      {
+        name: 'DeepSeek-R1-Distill-Llama-8B.Q4_K_M.gguf',
+        size: '4.92 GB',
+        thinking: '正在解析 <think> 推理鏈：1. 檢索本地 SQLite 數據庫；2. 匹配 KV Cache 快取前綴；3. 生成結構化思考步驟...',
+        response: 'DeepSeek-R1 本地推理完成！思考耗時 1.2 秒，全流式 Metal GPU 加速輸出與 KV Cache 快取前綴複用正常。'
+      },
+      {
+        name: 'Gemma-2-9B-Instruct.Q4_K_M.gguf',
+        size: '5.42 GB',
+        thinking: 'Checking local GGUF memory budget and Metal GPU offload layers...',
+        response: 'Gemma 2 9B local execution complete. All memory and KV offload operating strictly within iOS sandbox limits.'
+      }
+    ]
   },
   mcpSkillsSection: {
     badge: '工具與生態',
     title: 'MCP 協議 · Agent Skills · 沙盒 JS',
-    lead: '集成 Swift Model Context Protocol (MCP) 官方 SDK，支援從 GitHub 一鍵導入 Agent Skills 技能包，並可在沙盒內運行自定義 JavaScript 工具。'
+    lead: '集成 Swift Model Context Protocol (MCP) 官方 SDK，支援從 GitHub 一鍵導入 Agent Skills 技能包，並可在沙盒內運行自定義 JavaScript 工具。',
+    tabs: [
+      {
+        id: 'mcp',
+        type: 'MCP SERVER',
+        title: 'Built-in App Tool MCP',
+        badge: 'Official Swift MCP SDK',
+        desc: '在 AI 想要獲取設備時間或查詢沙盒時，統一通過內建 MCP 伺服器調度，且支援原生問答 Sheet 審批策略。',
+        snippet: `// Built-in App Tool MCP Execution
+{
+  "server": "etos_builtin_app_tool",
+  "tool": "app_get_system_time",
+  "arguments": { "timezone": "Asia/Taipei" },
+  "approval": "ASK_USER_CONFIRMATION"
+}`
+      },
+      {
+        id: 'skills',
+        type: 'AGENT SKILLS',
+        title: 'GitHub 技能包一鍵導入',
+        badge: 'Agentic Skill Pack',
+        desc: '直接粘貼 GitHub 倉庫鏈接或 RAW 檔案地址，即刻注入代碼審查、海報生成或工作流指令集。',
+        snippet: `# SKILL: CodeReviewer Pro
+description: "Inspect Swift & Rust diffs for memory leaks"
+tools: [app_read_sandbox_file, app_query_sqlite]
+instructions: |
+  Check for strong reference cycles in closure capture lists.`
+      },
+      {
+        id: 'jsc',
+        type: 'JSC JS TOOL',
+        title: 'JavaScriptCore 格式化工具',
+        badge: 'app_create_custom_jsc_js_tool',
+        desc: '創建可複用的 iOS JSC 自定義腳本工具，腳本聲明同步 function main(input)，保存在 CustomJSTools 目錄。',
+        snippet: `// CustomJSTools/format_currency.js
+// iOS JSC 執行引擎：同步函數，無 Node/fetch/Promise
+function main(input) {
+  var amount = input.amount || 0;
+  var currency = input.currency || 'USD';
+  return {
+    formatted: currency + ' ' + amount.toFixed(2),
+    timestamp: new Date().toISOString()
+  };
+}`
+      },
+      {
+        id: 'rag',
+        type: 'SQLCIPHER RAG',
+        title: 'SQLite 全盤物理加密向量庫',
+        badge: 'GRDB + SQLCipher',
+        desc: '本地 Embedding 與長效記憶直接落地在加密 SQLite 數據庫中，支援 SillyTavern 世界書觸發。',
+        snippet: `CREATE TABLE memory_vectors (
+  id TEXT PRIMARY KEY,
+  vector BLOB NOT NULL,
+  content TEXT NOT NULL,
+  created_at INTEGER NOT NULL
+) STRICT;`
+      }
+    ]
   },
   personalize: {
     title: '一眼認得出，是你的 Studio。',

--- a/docs/landing/src/i18n.js
+++ b/docs/landing/src/i18n.js
@@ -15,14 +15,16 @@ export const LANG_LIST = [
 
 const zh = {
   meta: {
-    title: 'ETOS LLM Studio',
-    subtitle: 'iPhone + Apple Watch 原生 AI 客户端'
+    title: 'ETOS LLM Studio · 原生 AI 客户端',
+    subtitle: 'iPhone + Apple Watch 原生 AI 客户端 · 端侧 LLM 与全能工具中心'
   },
   nav: {
-    features: '功能',
+    localModel: '端侧 LLM',
+    features: '功能矩阵',
+    mcpSkills: '工具与技能',
     personalize: '个性化',
-    privacy: '隐私',
-    tech: '技术',
+    privacy: '隐私与安全',
+    tech: '技术栈',
     docs: '文档',
     github: 'GitHub',
     download: '获取 App'
@@ -30,11 +32,29 @@ const zh = {
   hero: {
     title: '你的 AI，揣在手里，戴在腕上。',
     lead:
-      '运行在 iPhone 与 Apple Watch 上的原生 LLM 客户端。你的 Key、你的数据，从设备直接发往模型，没有中间服务器。',
-    actionsPrimary: '轻松上手',
-    actionsSecondary: '查看功能模块',
-    statusOnline: '正在维护中',
+      '运行在 iPhone 与 Apple Watch 上的原生 LLM 客户端。支持 GGUF 端侧本地模型、MCP 工具协议、Agent Skills 与 SQLCipher 物理加密。你的 Key、你的数据，零中间服务器。',
+    actionsPrimary: '轻松上手教程',
+    actionsSecondary: '探索功能模块',
+    statusOnline: '持续迭代中 · 750+ Swift 源文件',
     statusBadge: 'BUILT FOR APPLE PLATFORMS'
+  },
+  stats: [
+    { label: 'Swift 源文件', val: '750+' },
+    { label: '原生 Swift 代码行', val: '280,000+' },
+    { label: '中间服务器', val: '0' },
+    { label: '隐私与物理加密', val: '100% Local' }
+  ],
+  localDemo: {
+    badge: '端侧本地模型',
+    title: 'iOS 端侧硬核 GGUF 本地模型推理',
+    lead: '不需要连接任何网络或 API 服务。底层通过 llama.cpp C ABI 桥接，直接在 iPhone 上加载 GGUF 权重，并提供实时 CPU / Metal / 内存性能监视器。',
+    selectModelLabel: '选择本地 GGUF 模型',
+    thinkHeader: '本地模型思考时间线 (Thinking Timeline)'
+  },
+  mcpSkillsSection: {
+    badge: '工具与生态',
+    title: 'MCP 协议 · Agent Skills · 沙盒 JS',
+    lead: '集成 Swift Model Context Protocol (MCP) 官方 SDK，支持从 GitHub 一键导入 Agent Skills 技能包，并可在沙盒内运行自定义 JavaScript 工具。'
   },
   personalize: {
     title: '一眼认得出，是你的 Studio。',
@@ -48,7 +68,7 @@ const zh = {
     chat: {
       title: '问候与帮助',
       user: '你好',
-      bot: '你好！👋\n很高兴见到你，有什么想聊的或者需要帮忙的吗？无论是图片处理、海报设计、提示词编写、角色设定，还是其他问题，都可以直接告诉我。',
+      bot: '你好！👋\n很高兴见到你，有什么想聊的或者需要帮忙的吗？无论是端侧 GGUF 调参、MCP 工具配置、Agent Skills 导入，还是日常问答，都可以直接告诉我。',
       placeholder: '输入消息…'
     }
   },
@@ -57,64 +77,78 @@ const zh = {
     lead: '主界面只留聊天，其余全部收进设置。下面这些是你装好之后会陆续找到的能力。',
     items: [
       {
-        kicker: '01 / CHAT',
+        kicker: '01 / CHAT & PROVIDERS',
         title: '多模型 · 多 Provider · 兼容到底',
         body:
-          '原生适配 OpenAI Chat、OpenAI Responses、Anthropic、Gemini，外加任意 OpenAI 兼容接口。支持多 Key 轮询、参数表达式、原始 JSON 请求体、提供商级 / 全局两层代理。',
-        tags: ['OpenAI', 'Claude', 'Gemini', 'Custom']
+          '原生适配 OpenAI Chat、OpenAI Responses、Anthropic、Gemini，外加任意 OpenAI 兼容接口。支持多 Key 轮询、参数表达式、原始 JSON 请求体、单条 AI 回复重写与计费估算。',
+        tags: ['OpenAI', 'Claude', 'Gemini', 'Custom JSON']
       },
       {
-        kicker: '02 / TOOLS',
-        title: 'MCP · Skills · 快捷指令',
+        kicker: '02 / LOCAL GGUF',
+        title: '端侧 GGUF 本地模型 & 性能监视器',
         body:
-          '工具中心统一管理 MCP 服务器、Agent Skills 技能包、iOS 快捷指令、内置工具。支持会话级启用、审批策略、流式调试与连线时间线。',
-        tags: ['MCP', 'Skills', 'Shortcuts', '审批策略']
+          '底层通过 llama.cpp C ABI 桥接，在 iOS 上直接运行 GGUF 本地权重。支持 Metal GPU 加速、Flash Attention、KV offload、流式思考解析与浮动性能监视面板（CPU/Metal/RAM）。',
+        tags: ['llama.cpp', 'GGUF', 'Metal GPU', '性能 HUD']
       },
       {
-        kicker: '03 / MEMORY',
-        title: '长期记忆 · 世界书 · 用户画像',
+        kicker: '03 / TOOLS & SKILLS',
+        title: 'MCP 协议 · Agent Skills · 沙盒 JS',
         body:
-          '跨会话的事实记忆、关键词触发的世界书条目、模型可读的用户画像。本地向量索引，离线可用，可与每日脉冲联动。',
-        tags: ['长期记忆', '世界书', '本地 RAG']
+          '统一管理 MCP 服务器（Streamable HTTP/SSE）、Agent Skills 技能包（GitHub/RAW 导入）、iOS 快捷指令与内建 SQLite/文件沙盒/健康/日历工具，具备原生问答Sheet审批控制。',
+        tags: ['MCP SDK', 'Agent Skills', 'Shortcuts', '审批 Sheet']
       },
       {
-        kicker: '04 / DAILY PULSE',
-        title: '主动情报，不是被动问答',
+        kicker: '04 / RAG & WORLDBOOK',
+        title: '本地 RAG 记忆 · 世界书 · 嵌入向量',
         body:
-          '按你设定的节奏自动生成情报卡片：新闻、邮件提醒、日程预判、技术摘要。Watch 端会在抬腕时呈现，错过的可在 iPhone 端回看。',
-        tags: ['定时', '情报卡片', 'Watch 抬腕']
+          '跨会话长期事实记忆、支持 SillyTavern 兼容的世界书 Lorebook（条件触发、注入预算）与用户画像。向量索引完全本地 SQLite 运行，绝不下发云端。',
+        tags: ['长期记忆', '世界书 Lorebook', 'SQLite 向量']
       },
       {
-        kicker: '05 / SYNC',
-        title: 'iPhone ↔ Watch 局域网直连同步',
+        kicker: '05 / DAILY PULSE',
+        title: 'Daily Pulse 每日脉冲主动情报',
         body:
-          '不走服务器、不走 iCloud（除非你愿意）。双端通过 WatchConnectivity 与本地点对点协议互传，SQLCipher 全盘加密，可导出 ETOS 数据包随时迁移。',
-        tags: ['WatchConnectivity', 'SQLCipher', 'ETOS 数据包']
+          '每天定时预生成主动情报卡片：新闻、邮件提醒、日程预判、技术摘要。支持卡片一键转待跟进任务与长效偏好反馈学习，抬腕即看。',
+        tags: ['定时', '情报卡片', '任务跟进', 'Watch 抬腕']
       },
       {
-        kicker: '06 / WATCH',
+        kicker: '06 / WATCH & SYNC',
+        title: 'iPhone ↔ Watch 权威增量同步',
+        body:
+          'WatchConnectivity 局域网快速通道 + CloudKit / APNs 后台漫游。双端配备权威世代指针与数据覆盖冲突裁决短语，离线分叉合并零丢失。',
+        tags: ['WatchConnectivity', 'CloudKit', '世代指针']
+      },
+      {
+        kicker: '07 / WATCH NATIVE',
         title: '手腕上的完整体验，不是阉割版',
         body:
           '数码表冠缩放图片、Markdown 与代码高亮、思考时间线、TTS 朗读、单会话跨端发送。watchOS 设置扁平化为单层 List，零 TabView。',
-        tags: ['watchOS', '数码表冠', '抬腕语音']
+        tags: ['watchOS', '数码表冠', '抬腕语音', 'TTS']
+      },
+      {
+        kicker: '08 / SECURITY & BACKUP',
+        title: 'SQLCipher 全盘加密 & 快照备份',
+        body:
+          '底层数据库采用 SQLCipher 物理加密，结合 PBKDF2 主密码与 Face ID / Touch ID 应用锁。支持加密快照 `.elsbackup` 导出及 Cloudflare R2 / S3 签名云备份。',
+        tags: ['SQLCipher', 'Face ID 锁', 'AES-256', 'S3/R2 云备份']
       }
     ]
   },
   screenshots: {
     title: '看看它在你手里是什么样。',
-    lead: '截图直接来自当前版本。',
-    captionOne: 'iOS · 聊天主界面',
-    captionTwo: 'Apple Watch · 单会话回看'
+    lead: '截图直接来自当前真实 Build。',
+    captionOne: 'iOS · 聊天与功能面板',
+    captionTwo: 'Apple Watch · 独立端侧体验'
   },
   privacy: {
     title: '你的 Key，你的数据，你的设备。',
     lead:
-      '没有任何中间服务器。模型请求从你的设备直接发出，对话存在本机 SQLite（SQLCipher 加密），同步通过 iPhone 与 Watch 在局域网内完成。要不要上 CloudKit、要不要交给第三方，全是你的选择。',
+      '没有任何中间服务器。模型请求从你的设备直接发出，对话存在本机 SQLite（SQLCipher 加密），同步通过 iPhone 与 Watch 在局域网或 CloudKit 完成。要不要交给第三方，全是你的选择。',
     bullets: [
       { kicker: 'BYOK', title: '你提供 Key，App 直发模型', body: '我们不代付、不转发、不缓存你的请求。' },
-      { kicker: 'LOCAL FIRST', title: '会话与记忆存在本机', body: 'SQLCipher 全盘加密，可应用锁 + Face ID 双重门。' },
-      { kicker: 'EXPORTABLE', title: 'ETOS 数据包，随时拎走', body: '一键导出/导入，迁移设备不是难题。' },
-      { kicker: 'OPEN SOURCE', title: 'GPLv3 开源', body: '代码可审计，PR 与 Issue 都欢迎。' }
+      { kicker: 'LOCAL FIRST', title: '会话与记忆存在本机', body: 'SQLCipher 全盘加密，配合 Face ID 应用锁。' },
+      { kicker: 'EXPORTABLE', title: 'ETOS 数据包与加密快照', body: '一键导出/导入 `.elsbackup`，跨端迁移无痛。' },
+      { kicker: 'OPEN SOURCE', title: 'GPLv3 开源', body: '代码完全公开可审计，欢迎 PR 与 Issue。' }
     ]
   },
   tech: {
@@ -122,11 +156,11 @@ const zh = {
     lead: '没有 Electron，没有 React Native，没有 WebView 套壳。快速，性能超强。',
     items: [
       { name: 'Swift 6 · SwiftUI', desc: 'iOS 18 + watchOS 11 原生 UI，遵循 Apple HIG。' },
-      { name: 'GRDB · SQLCipher', desc: '加密 SQLite + ValueObservation 响应式查询。' },
-      { name: 'WatchConnectivity', desc: '双端低延迟同步，无中间服务器。' },
-      { name: 'Background Tasks', desc: 'Daily Pulse 在后台预生成，抬腕即看。' },
-      { name: 'SF Symbols 6', desc: '原生图标体系，与系统视觉一致。' },
-      { name: 'App Intents', desc: 'Siri 快捷指令与 Spotlight 深度集成。' }
+      { name: 'llama.cpp C ABI', desc: 'iOS 端侧运行 GGUF 权重，Metal GPU 加速与性能 HUD。' },
+      { name: 'Swift MCP SDK', desc: 'Model Context Protocol 官方 SDK，支持 SSE / Streamable HTTP。' },
+      { name: 'GRDB · SQLCipher', desc: '物理全盘加密 SQLite + ValueObservation 响应式查询。' },
+      { name: 'WatchConnectivity & CloudKit', desc: '双端低延迟增量同步，带世代指针与 APNs 静默唤醒。' },
+      { name: 'SFSpeechRecognizer & TTS', desc: '系统与云端语音识别及朗读引擎，实时回填与自动回退。' }
     ]
   },
   cta: {
@@ -157,26 +191,46 @@ const zh = {
 
 const en = {
   meta: {
-    title: 'ETOS LLM Studio',
-    subtitle: 'A native AI client for iPhone + Apple Watch'
+    title: 'ETOS LLM Studio · Native AI Client',
+    subtitle: 'Native AI Client for iPhone + Apple Watch · On-Device LLM & Powerful Tooling'
   },
   nav: {
+    localModel: 'On-Device LLM',
     features: 'Features',
+    mcpSkills: 'MCP & Skills',
     personalize: 'Personalize',
-    privacy: 'Privacy',
+    privacy: 'Privacy & Security',
     tech: 'Stack',
     docs: 'Docs',
     github: 'GitHub',
-    download: 'Get the App'
+    download: 'Get App'
   },
   hero: {
     title: 'AI in your pocket. And on your wrist.',
     lead:
-      'A native LLM client that runs on iPhone and Apple Watch. Your key, your data — straight from device to model. No middle server.',
-    actionsPrimary: 'Read the quickstart',
-    actionsSecondary: 'See the modules',
-    statusOnline: 'In active development',
+      'A native LLM client that runs on iPhone and Apple Watch. Supporting GGUF on-device local models, MCP protocol, Agent Skills, and SQLCipher physical encryption. Zero middle server.',
+    actionsPrimary: 'Read Quickstart Guide',
+    actionsSecondary: 'Explore Feature Matrix',
+    statusOnline: 'Active Development · 750+ Swift Files',
     statusBadge: 'BUILT FOR APPLE PLATFORMS'
+  },
+  stats: [
+    { label: 'Swift Source Files', val: '750+' },
+    { label: 'Native Swift Code Lines', val: '280,000+' },
+    { label: 'Middle Servers', val: '0' },
+    { label: 'Privacy & Physical Encryption', val: '100% Local' }
+  ],
+  localDemo: {
+    badge: 'On-Device Local Model',
+    title: 'Native GGUF Inference & Performance HUD on iOS',
+    lead: 'No network or API keys needed. Bridged via llama.cpp C ABI directly on iOS with Metal GPU acceleration and real-time CPU / Metal / Memory telemetry.',
+    selectModelLabel: 'Select Local GGUF Model',
+    thinkHeader: 'Thinking Timeline'
+  },
+  mcpSkillsSection: {
+    badge: 'Tools & Ecosystem',
+    title: 'MCP Protocol · Agent Skills · Sandboxed JS',
+    lead: 'Official Swift Model Context Protocol SDK, one-click Agent Skill import from GitHub, and sandboxed JavaScript tool runtime.',
   },
   personalize: {
     title: 'Unmistakably yours.',
@@ -190,7 +244,7 @@ const en = {
     chat: {
       title: 'Greetings & Help',
       user: 'Hi',
-      bot: "Hi! 👋\nGreat to meet you — anything you'd like to chat about or need a hand with? Image editing, poster design, prompt writing, character setup, or anything else, just tell me.",
+      bot: "Hi! 👋\nGreat to meet you — anything you'd like to chat about or need a hand with? GGUF local model tuning, MCP tools, Agent Skills, or prompt engineering, just ask!",
       placeholder: 'Message'
     }
   },
@@ -199,64 +253,78 @@ const en = {
     lead: 'The main view is just chat. Everything else lives in Settings. Here is what you will gradually find.',
     items: [
       {
-        kicker: '01 / CHAT',
-        title: 'Multi-model · Multi-provider · Compatible to the end',
+        kicker: '01 / CHAT & PROVIDERS',
+        title: 'Multi-model · Multi-provider · Total Compatibility',
         body:
-          'Native support for OpenAI Chat, OpenAI Responses, Anthropic, Gemini, plus any OpenAI-compatible endpoint. Key rotation, parameter expressions, raw JSON body, two-layer proxy.',
-        tags: ['OpenAI', 'Claude', 'Gemini', 'Custom']
+          'Native support for OpenAI Chat, OpenAI Responses, Anthropic, Gemini, plus any OpenAI-compatible endpoint. Key rotation, parameter expressions, raw JSON, single response rewrite, and cost tracking.',
+        tags: ['OpenAI', 'Claude', 'Gemini', 'Custom JSON']
       },
       {
-        kicker: '02 / TOOLS',
-        title: 'MCP · Skills · Shortcuts',
+        kicker: '02 / LOCAL GGUF',
+        title: 'On-Device GGUF Models & Performance HUD',
         body:
-          'A single tool hub unifies MCP servers, Agent Skills, iOS Shortcuts, and built-ins. Per-session toggles, approval policy, streaming debug, and a tool-call timeline.',
-        tags: ['MCP', 'Skills', 'Shortcuts', 'Approval']
+          'Bridged via llama.cpp C ABI to execute GGUF weights directly on iOS. Metal GPU acceleration, Flash Attention, KV offload, streaming thinking tags, and floating performance monitor HUD.',
+        tags: ['llama.cpp', 'GGUF', 'Metal GPU', 'HUD']
       },
       {
-        kicker: '03 / MEMORY',
-        title: 'Long-term memory · Worldbook · User profile',
+        kicker: '03 / TOOLS & SKILLS',
+        title: 'MCP Protocol · Agent Skills · Sandboxed JS',
         body:
-          'Cross-session facts, keyword-triggered worldbook entries, a model-readable user profile. Local vector index, works offline, plugs into Daily Pulse.',
-        tags: ['Memory', 'Worldbook', 'Local RAG']
+          'Unified tool hub managing MCP servers (SSE/HTTP), Agent Skills (GitHub/RAW import), Shortcuts, SQLite/sandboxed files/Health/Calendar tools with native approval Sheets.',
+        tags: ['MCP SDK', 'Agent Skills', 'Shortcuts', 'Approval Sheet']
       },
       {
-        kicker: '04 / DAILY PULSE',
-        title: 'Proactive briefing, not passive Q&A',
+        kicker: '04 / RAG & WORLDBOOK',
+        title: 'Local RAG Memory · Worldbook · SQLite Vectors',
         body:
-          'Cards generated on your schedule: news, mail nudges, calendar prep, tech digests. Watch shows them on raise; iPhone keeps the backlog.',
-        tags: ['Scheduled', 'Cards', 'Raise to view']
+          'Cross-session facts, SillyTavern compatible Worldbook lorebook (conditional triggers, budget control), and user profile. Vector database runs 100% locally in SQLite.',
+        tags: ['Memory', 'Worldbook', 'Local RAG', 'SQLite']
       },
       {
-        kicker: '05 / SYNC',
-        title: 'iPhone ↔ Watch over LAN',
+        kicker: '05 / DAILY PULSE',
+        title: 'Daily Pulse Proactive Intelligence',
         body:
-          'No server, no iCloud (unless you opt in). Peer-to-peer over WatchConnectivity and local protocols. SQLCipher full-disk encryption. Export an ETOS bundle to migrate.',
-        tags: ['WatchConnectivity', 'SQLCipher', 'ETOS bundle']
+          'Pre-generated intelligence cards (news, calendar prep, tech digests). Convert cards into actionable follow-up tasks with feedback learning and Apple Watch raise-to-view.',
+        tags: ['Scheduled', 'Cards', 'Task Tracking', 'Watch Raise']
       },
       {
-        kicker: '06 / WATCH',
-        title: 'A complete experience on the wrist — not a crippled one',
+        kicker: '06 / WATCH & SYNC',
+        title: 'iPhone ↔ Watch Authority Sync',
         body:
-          'Digital Crown zoom, Markdown + code highlighting, thinking timeline, TTS readout, cross-device send. watchOS settings stay flat — one List, no TabView.',
-        tags: ['watchOS', 'Digital Crown', 'Voice']
+          'WatchConnectivity low-latency channel + CloudKit / APNs background sync. Equipped with generation pointers and conflict resolution phrase for zero data loss.',
+        tags: ['WatchConnectivity', 'CloudKit', 'Generation Pointers']
+      },
+      {
+        kicker: '07 / WATCH NATIVE',
+        title: 'A complete experience on the wrist',
+        body:
+          'Digital Crown zoom, Markdown + code highlighting, thinking timeline, TTS readout, cross-device send. Flat single-layer list layout without TabView.',
+        tags: ['watchOS', 'Digital Crown', 'Voice', 'TTS']
+      },
+      {
+        kicker: '08 / SECURITY & BACKUP',
+        title: 'SQLCipher Encryption & Cloud Backups',
+        body:
+          'Physical SQLCipher database encryption with PBKDF2 master key & Face ID app lock. Encrypted `.elsbackup` snapshots and S3 / Cloudflare R2 cloud backup.',
+        tags: ['SQLCipher', 'Face ID', 'AES-256', 'S3/R2 Backup']
       }
     ]
   },
   screenshots: {
     title: 'See what it looks like in your hand.',
-    lead: 'Screens are from the current build.',
-    captionOne: 'iOS · Chat',
-    captionTwo: 'Apple Watch · Session view'
+    lead: 'Screens are from the current real build.',
+    captionOne: 'iOS · Chat & Features',
+    captionTwo: 'Apple Watch · Session View'
   },
   privacy: {
     title: 'Your key. Your data. Your device.',
     lead:
-      'ETOS runs no server of its own. Requests go from your device straight to the model. Chats live in local SQLite (SQLCipher). Sync happens over your LAN between iPhone and Watch. CloudKit? Third-party? Only if you choose.',
+      'ETOS runs no server of its own. Requests go from your device straight to the model. Chats live in local SQLite (SQLCipher encrypted). Sync happens over LAN or CloudKit.',
     bullets: [
       { kicker: 'BYOK', title: 'You bring the key', body: 'We never proxy, cache, or bill your requests.' },
-      { kicker: 'LOCAL FIRST', title: 'Chats live on device', body: 'SQLCipher encryption + app lock with Face ID.' },
-      { kicker: 'EXPORTABLE', title: 'Take the data with you', body: 'One-click ETOS bundle export/import for migrations.' },
-      { kicker: 'OPEN SOURCE', title: 'GPLv3, auditable', body: 'Code is open. PRs and issues welcome.' }
+      { kicker: 'LOCAL FIRST', title: 'Chats live on device', body: 'SQLCipher physical encryption + Face ID app lock.' },
+      { kicker: 'EXPORTABLE', title: 'Take data with you', body: 'One-click `.elsbackup` snapshot export/import for effortless migrations.' },
+      { kicker: 'OPEN SOURCE', title: 'GPLv3 License', body: 'Code is open and auditable. PRs and issues welcome.' }
     ]
   },
   tech: {
@@ -264,11 +332,11 @@ const en = {
     lead: 'No Electron. No React Native. No WebView shell.',
     items: [
       { name: 'Swift 6 · SwiftUI', desc: 'iOS 18 + watchOS 11, true to Apple HIG.' },
+      { name: 'llama.cpp C ABI', desc: 'Runs GGUF weights on-device with Metal GPU & HUD.' },
+      { name: 'Swift MCP SDK', desc: 'Official Model Context Protocol SDK for Swift.' },
       { name: 'GRDB · SQLCipher', desc: 'Encrypted SQLite with reactive ValueObservation.' },
-      { name: 'WatchConnectivity', desc: 'Low-latency sync. No middle server.' },
-      { name: 'Background Tasks', desc: 'Daily Pulse pre-renders in the background.' },
-      { name: 'SF Symbols 6', desc: 'Stays visually consistent with the system.' },
-      { name: 'App Intents', desc: 'Deep Siri Shortcuts and Spotlight hooks.' }
+      { name: 'WatchConnectivity & CloudKit', desc: 'Low-latency sync with generation pointers and APNs.' },
+      { name: 'SFSpeechRecognizer & TTS', desc: 'System and cloud speech engines with automatic fallback.' }
     ]
   },
   cta: {
@@ -299,134 +367,159 @@ const en = {
 
 const ja = {
   meta: {
-    title: 'ETOS LLM Studio',
-    subtitle: 'iPhone と Apple Watch のためのネイティブ AI クライアント'
+    title: 'ETOS LLM Studio · ネイティブ AI クライアント',
+    subtitle: 'iPhone + Apple Watch 向けネイティブ AI クライアント'
   },
   nav: {
+    localModel: 'ローカル LLM',
     features: '機能',
+    mcpSkills: 'ツールとスキル',
     personalize: 'カスタマイズ',
     privacy: 'プライバシー',
-    tech: '技術',
+    tech: '技術スタック',
     docs: 'ドキュメント',
     github: 'GitHub',
-    download: 'App を入手'
+    download: 'アプリを入手'
   },
   hero: {
-    title: 'AI をポケットに、そして手首に。',
+    title: 'AI を、手の中に。腕の上に。',
     lead:
-      'iPhone と Apple Watch 上で動くネイティブ LLM クライアント。あなたの Key、あなたのデータが、デバイスから直接モデルへ。中継サーバーはありません。',
+      'iPhone と Apple Watch で動作するネイティブ LLM クライアント。オンデバイス GGUF ローカルモデル、MCP プロトコル、Agent Skills、SQLCipher 暗号化をサポート。中間サーバーゼロ。',
     actionsPrimary: 'クイックスタートを読む',
-    actionsSecondary: '機能モジュール',
-    statusOnline: '開発中',
+    actionsSecondary: '機能を見る',
+    statusOnline: 'アクティブに開発中 · 750+ Swift ファイル',
     statusBadge: 'BUILT FOR APPLE PLATFORMS'
   },
+  stats: [
+    { label: 'Swift ソースファイル', val: '750+' },
+    { label: 'Swift コード行数', val: '280,000+' },
+    { label: '中間サーバー', val: '0' },
+    { label: '物理暗号化・ローカルファースト', val: '100% Local' }
+  ],
+  localDemo: {
+    badge: 'オンデバイスローカルモデル',
+    title: 'iOS 上での GGUF 推論 & パフォーマンス HUD',
+    lead: 'ネット接続や API キーは一切不要。llama.cpp C ABI 経由で Metal GPU アクセラレーションとリアルタイム CPU/GPU/メモリ モニターを搭載。',
+    selectModelLabel: 'ローカル GGUF モデルを選択',
+    thinkHeader: '思考タイムライン (Thinking Timeline)'
+  },
+  mcpSkillsSection: {
+    badge: 'ツールとエコシステム',
+    title: 'MCP プロトコル · Agent Skills · Sandboxed JS',
+    lead: '公式 Swift MCP SDK、GitHub からのワンクリック Agent Skill インポート、サンドボックス化 JavaScript ランタイムを搭載。'
+  },
   personalize: {
-    title: 'ひと目で分かる、あなたの Studio。',
-    lead: '壁紙をアップロード、バブルの色を選ぶ、AI バブルの有無——右のスマホがリアルタイムで反映します。',
-    pickerHint: '下の3項目を調整、右でプレビュー',
+    title: 'あなただけの Studio。',
+    lead: '壁紙をアップロードし、バブルの色を選び、AI バブルの表示をカスタマイズ。右側のプレビューがリアルタイムで更新されます。',
+    pickerHint: '下で調整、右側でリアルタイム確認',
     wallpaperLabel: '背景レイヤー',
     wallpaperAction: '背景画像を選択',
     colorLabel: 'カラープロファイル',
-    hideBubbleLabel: 'アシスタントの吹き出しを非表示',
+    hideBubbleLabel: '助手バブルを非表示',
     reset: 'デフォルトに戻す',
     chat: {
-      title: 'あいさつとヘルプ',
+      title: '挨拶とサポート',
       user: 'こんにちは',
-      bot: 'こんにちは！👋\nお会いできてうれしいです。話したいことや、お手伝いできることはありますか？画像処理、ポスターデザイン、プロンプト作成、キャラクター設定、その他なんでも、気軽にどうぞ。',
-      placeholder: 'メッセージ'
+      bot: 'こんにちは！👋\n何かお手伝いできることはありますか？ローカル GGUF モデルの調整、MCP ツール、Agent Skills のインポートなど、何でもお気軽にどうぞ！',
+      placeholder: 'メッセージを入力…'
     }
   },
   features: {
-    title: 'ガワだけではない。Apple プラットフォームの一員として設計。',
-    lead: 'メイン画面はチャットのみ。残りはすべて設定に。インストール後に少しずつ見つかる機能たちです。',
+    title: '単なる Web ラッパーではありません。',
+    lead: 'メイン画面はチャットのみ。その他はすべて設定に集約。',
     items: [
       {
-        kicker: '01 / CHAT',
-        title: 'マルチモデル · マルチプロバイダ · どこまでも互換',
-        body:
-          'OpenAI Chat / Responses、Anthropic、Gemini にネイティブ対応。任意の OpenAI 互換 API も。Key ローテーション、パラメータ式、生 JSON ボディ、二層プロキシ。',
-        tags: ['OpenAI', 'Claude', 'Gemini', 'カスタム']
+        kicker: '01 / CHAT & PROVIDERS',
+        title: 'マルチモデル · マルチプロバイダー',
+        body: 'OpenAI、Claude、Gemini、任意の OpenAI 互換 API をサポート。キーローテーション、カスタムパラメータ式、JSON プレビューに対応。',
+        tags: ['OpenAI', 'Claude', 'Gemini', 'Custom']
       },
       {
-        kicker: '02 / TOOLS',
-        title: 'MCP · Skills · ショートカット',
-        body:
-          '統合ツールセンターが MCP サーバー、Agent Skills、iOS ショートカット、組み込みツールを一括管理。会話単位の ON/OFF、承認ポリシー、ストリーミングデバッグ。',
-        tags: ['MCP', 'Skills', 'Shortcuts', '承認']
+        kicker: '02 / LOCAL GGUF',
+        title: 'オンデバイス GGUF ローカルモデル & HUD',
+        body: 'llama.cpp C ABI 経由で iOS 上で直接 GGUF モデルを実行。Metal GPU アクセラレーション、Flash Attention、リアルタイム HUD を搭載。',
+        tags: ['llama.cpp', 'GGUF', 'Metal GPU', 'HUD']
       },
       {
-        kicker: '03 / MEMORY',
-        title: '長期記憶 · ワールドブック · ユーザープロファイル',
-        body:
-          '会話をまたぐ事実、キーワードでトリガーされるワールドブック、モデルが読めるプロファイル。ローカルベクター検索、オフライン可、Daily Pulse 連携。',
-        tags: ['長期記憶', 'ワールドブック', 'ローカル RAG']
+        kicker: '03 / TOOLS & SKILLS',
+        title: 'MCP プロトコル · Agent Skills · JS ツール',
+        body: 'MCP サーバー、Agent Skills、Shortcuts、SQLite/ファイル操作/ヘルスケア/カレンダーツールを統括。',
+        tags: ['MCP SDK', 'Agent Skills', 'Shortcuts']
       },
       {
-        kicker: '04 / DAILY PULSE',
-        title: '受け身ではなく、先回り。',
-        body:
-          'スケジュールに沿ってカードを自動生成：ニュース、メールリマインダ、予定の前準備、技術ダイジェスト。Watch では手首を上げると表示。',
-        tags: ['スケジュール', 'カード', '抬腕']
+        kicker: '04 / RAG & WORLDBOOK',
+        title: 'ローカル RAG 記憶 · ワールドブック',
+        body: '長期記憶、SillyTavern 互換のワールドブック (Lorebook)、ユーザープロファイル。ベクトルインデックスは完全にローカル SQLite で動作。',
+        tags: ['Memory', 'Worldbook', 'SQLite']
       },
       {
-        kicker: '05 / SYNC',
-        title: 'iPhone ↔ Watch を LAN で直結同期',
-        body:
-          'サーバー経由なし、iCloud も任意。WatchConnectivity と P2P プロトコルで双方向。SQLCipher 全体暗号化、ETOS バンドルで持ち運び可。',
-        tags: ['WatchConnectivity', 'SQLCipher', 'ETOS バンドル']
+        kicker: '05 / DAILY PULSE',
+        title: 'Daily Pulse アクティブインテリジェンス',
+        body: '毎日自動でインテリジェンスカードを生成。アクションアイテムへの変換、フィードバック学習、Watch での確認に対応。',
+        tags: ['Scheduled', 'Cards', 'Watch']
       },
       {
-        kicker: '06 / WATCH',
-        title: '手首でもフル体験。簡易版ではありません。',
-        body:
-          'デジタルクラウンでズーム、Markdown とコードハイライト、思考タイムライン、TTS、双方向送信。watchOS の設定は単層 List のみ、TabView は使いません。',
-        tags: ['watchOS', 'デジタルクラウン', '音声入力']
+        kicker: '06 / WATCH & SYNC',
+        title: 'iPhone ↔ Watch 同期',
+        body: 'WatchConnectivity & CloudKit バックグラウンド漫遊。世代ポインタと競合自動解決を搭載。',
+        tags: ['WatchConnectivity', 'CloudKit']
+      },
+      {
+        kicker: '07 / WATCH NATIVE',
+        title: '手首の上の完全な体験',
+        body: 'Digital Crown ズーム、Markdown + コードハイライト、思考タイムライン、TTS 読み上げをサポート。',
+        tags: ['watchOS', 'Digital Crown', 'Voice']
+      },
+      {
+        kicker: '08 / SECURITY & BACKUP',
+        title: 'SQLCipher 暗号化 & クラウドバックアップ',
+        body: 'SQLCipher 物理全盤暗号化、PBKDF2 + Face ID アプリロック。暗号化 `.elsbackup` や S3 / Cloudflare R2 クラウドバックアップに対応。',
+        tags: ['SQLCipher', 'Face ID', 'S3/R2']
       }
     ]
   },
   screenshots: {
-    title: '実機での姿を、そのまま。',
-    lead: '現行ビルドからのスクリーンショット。',
-    captionOne: 'iOS · チャット',
-    captionTwo: 'Apple Watch · 会話ビュー'
+    title: '実際の画面をご覧ください。',
+    lead: '現在のリアルビルドからのスクリーンショットです。',
+    captionOne: 'iOS · チャット画面',
+    captionTwo: 'Apple Watch · セッション画面'
   },
   privacy: {
-    title: 'あなたの Key、データ、デバイス。',
-    lead:
-      'ETOS は自前のサーバーを持ちません。リクエストはデバイスから直接モデルへ。会話はローカル SQLite に SQLCipher で暗号化保存。同期は iPhone と Watch の LAN 直結。CloudKit や第三者連携は完全にオプトインです。',
+    title: 'あなたの Key、あなたのデータ。',
+    lead: '中継サーバーはありません。リクエストはあなたのデバイスからモデルへ直接送信され、会話はローカル SQLite (SQLCipher) に保存されます。',
     bullets: [
-      { kicker: 'BYOK', title: 'Key はあなたが用意', body: 'こちらでプロキシも、キャッシュも、課金もしません。' },
-      { kicker: 'LOCAL FIRST', title: 'チャットは端末内', body: 'SQLCipher 暗号化 + Face ID アプリロック。' },
-      { kicker: 'EXPORTABLE', title: 'ETOS バンドルで持ち運び', body: '機種変更時もワンクリックで移行可能。' },
-      { kicker: 'OPEN SOURCE', title: 'GPLv3 オープンソース', body: 'コードは監査可能。PR と Issue を歓迎。' }
+      { kicker: 'BYOK', title: 'API Key は自身で管理', body: 'リクエストを転送・キャッシュ・課金することはありません。' },
+      { kicker: 'LOCAL FIRST', title: '端末内暗号化保存', body: 'SQLCipher 全盤暗号化 + Face ID ロック。' },
+      { kicker: 'EXPORTABLE', title: 'データのエクスポート', body: 'ワンクリックで `.elsbackup` パックを出力・移行可能。' },
+      { kicker: 'OPEN SOURCE', title: 'GPLv3 ライセンス', body: 'コードは公開されており監査可能です。' }
     ]
   },
   tech: {
-    title: 'ネイティブの道具で、ネイティブの感触を。',
-    lead: 'Electron も React Native も WebView ガワもありません。',
+    title: 'ネイティブツールによる極上のネイティブ体験。',
+    lead: 'Electron も React Native もなし。高速で強力。',
     items: [
-      { name: 'Swift 6 · SwiftUI', desc: 'iOS 18 + watchOS 11 のネイティブ UI、HIG 準拠。' },
-      { name: 'GRDB · SQLCipher', desc: '暗号化 SQLite と ValueObservation。' },
-      { name: 'WatchConnectivity', desc: '低遅延同期。中継サーバーなし。' },
-      { name: 'Background Tasks', desc: 'Daily Pulse はバックグラウンドで事前生成。' },
-      { name: 'SF Symbols 6', desc: 'システムの視覚と整合。' },
-      { name: 'App Intents', desc: 'Siri ショートカットと Spotlight 連携。' }
+      { name: 'Swift 6 · SwiftUI', desc: 'iOS 18 + watchOS 11 ネイティブ UI。' },
+      { name: 'llama.cpp C ABI', desc: 'iOS 上で GGUF を実行し Metal 加速。' },
+      { name: 'Swift MCP SDK', desc: '公式 Model Context Protocol SDK。' },
+      { name: 'GRDB · SQLCipher', desc: '暗号化 SQLite とレスポンシブクエリ。' },
+      { name: 'WatchConnectivity & CloudKit', desc: '低遅延の世代管理同期。' },
+      { name: 'SFSpeechRecognizer & TTS', desc: '音声認識と自動フォールバック付き読み上げ。' }
     ]
   },
   cta: {
-    title: '10 分で最初の会話を。',
-    lead: 'インストールから初回返信まで、どこを押すか毎ステップ明示します。',
-    primary: 'クイックスタート',
-    secondary: 'GitHub ソース',
-    secondaryDesc: 'Star・Issue・PR お待ちしています。'
+    title: '10分で最初の会話を。',
+    lead: 'インストールから最初の返信までわかりやすく案内します。',
+    primary: 'ガイドを読む',
+    secondary: 'GitHub で見る',
+    secondaryDesc: 'Star や Issue、PR 大歓迎。'
   },
   footer: {
     madeBy: 'Made with care by',
     author: 'Eric-Terminal',
-    license: 'GPL-3.0 ライセンス',
+    license: 'GPL-3.0 License',
     repo: 'github.com/Eric-Terminal/ETOS-LLM-Studio',
     docs: 'ドキュメント',
-    backToTop: 'トップへ戻る'
+    backToTop: 'トップに戻る'
   },
   loader: {
     kicker: 'HELLO FROM ETOS',
@@ -435,137 +528,162 @@ const ja = {
   },
   ui: {
     theme: { light: 'ライト', dark: 'ダーク' },
-    langHint: 'お好みの言語をどうぞ。'
+    langHint: '言語を選択してください。'
   }
 };
 
 const ru = {
   meta: {
-    title: 'ETOS LLM Studio',
-    subtitle: 'Нативный AI-клиент для iPhone и Apple Watch'
+    title: 'ETOS LLM Studio · Нативный AI-клиент',
+    subtitle: 'Нативный AI-клиент для iPhone + Apple Watch · Локальные GGUF модели'
   },
   nav: {
+    localModel: 'Локальный LLM',
     features: 'Возможности',
-    personalize: 'Оформление',
-    privacy: 'Приватность',
+    mcpSkills: 'MCP и Инструменты',
+    personalize: 'Персонализация',
+    privacy: 'Конфиденциальность',
     tech: 'Стек',
-    docs: 'Документация',
+    docs: 'Доки',
     github: 'GitHub',
-    download: 'Получить'
+    download: 'Скачать App'
   },
   hero: {
-    title: 'AI в кармане. И на запястье.',
+    title: 'Ваш ИИ. В кармане и на запястье.',
     lead:
-      'Нативный LLM-клиент для iPhone и Apple Watch. Ваш ключ, ваши данные — с устройства напрямую в модель. Никакого посредника.',
-    actionsPrimary: 'Краткое руководство',
-    actionsSecondary: 'Модули',
-    statusOnline: 'В активной разработке',
+      'Нативный LLM-клиент для iPhone и Apple Watch. Поддержка локальных GGUF моделей, MCP протокола, Agent Skills и шифрования SQLCipher. Без промежуточных серверов.',
+    actionsPrimary: 'Быстрый старт',
+    actionsSecondary: 'Модули и функции',
+    statusOnline: 'В активной разработке · 750+ Swift файлов',
     statusBadge: 'BUILT FOR APPLE PLATFORMS'
   },
+  stats: [
+    { label: 'Файлов Swift', val: '750+' },
+    { label: 'Строк кода Swift', val: '280,000+' },
+    { label: 'Промежуточных серверов', val: '0' },
+    { label: 'Локальное шифрование', val: '100% Local' }
+  ],
+  localDemo: {
+    badge: 'Локальная модель на устройстве',
+    title: 'Нативный GGUF инференс и HUD производительности на iOS',
+    lead: 'Работает полностью без интернета. Модели GGUF исполняются через C ABI llama.cpp с ускорением Metal GPU и онлайн-монитором CPU/Metal/Памяти.',
+    selectModelLabel: 'Выберите модель GGUF',
+    thinkHeader: 'Таймлайн размышлений (Thinking Timeline)'
+  },
+  mcpSkillsSection: {
+    badge: 'Инструменты и экосистема',
+    title: 'Протокол MCP · Agent Skills · Песочница JS',
+    lead: 'Официальный Swift MCP SDK, импорт Agent Skills с GitHub в один клик и изолированный запуск JS-скриптов.',
+  },
   personalize: {
-    title: 'Безошибочно ваша Studio.',
-    lead: 'Загрузите обои, выберите цвет пузыря, оставьте или уберите пузырь ИИ — телефон справа меняется вживую.',
-    pickerHint: 'Настройте три пункта, превью справа',
-    wallpaperLabel: 'Слой фона',
-    wallpaperAction: 'Выбрать фоновое изображение',
-    colorLabel: 'Цветовые профили',
-    hideBubbleLabel: 'Скрыть пузыри ассистента',
+    title: 'Ваш уникальный Studio.',
+    lead: 'Загрузите обои, выберите цвет баббла, настройте стиль AI — предпросмотр справа меняется в реальном времени.',
+    pickerHint: 'Настройте элементы слева',
+    wallpaperLabel: 'Фоновый слой',
+    wallpaperAction: 'Выбрать обои',
+    colorLabel: 'Цветовой профиль',
+    hideBubbleLabel: 'Скрыть баббл ассистента',
     reset: 'Сбросить',
     chat: {
-      title: 'Приветствие и помощь',
+      title: 'Приветствие',
       user: 'Привет',
-      bot: 'Привет! 👋\nРад знакомству! О чём хотите поговорить или с чем помочь? Обработка изображений, дизайн постеров, написание промптов, создание персонажей или что-то ещё — просто скажите.',
-      placeholder: 'Сообщение'
+      bot: 'Привет! 👋\nЧем я могу помочь? Локальные GGUF модели, MCP инструменты, Agent Skills или промпты — обращайтесь!',
+      placeholder: 'Сообщение…'
     }
   },
   features: {
-    title: 'Не обёртка. Гражданин платформы Apple.',
-    lead: 'Главный экран — только чат. Всё остальное живёт в «Настройках». Вот что вы найдёте, когда поставите.',
+    title: 'Не просто оболочка. Нативный гражданин экосистемы Apple.',
+    lead: 'Главный экран — это только чат. Всё остальное бережно убрано в Настройки.',
     items: [
       {
-        kicker: '01 / CHAT',
-        title: 'Много моделей · Много провайдеров · Совместимость до конца',
-        body:
-          'Нативная поддержка OpenAI Chat / Responses, Anthropic, Gemini и любых OpenAI-совместимых API. Ротация ключей, выражения параметров, сырое JSON-тело, двухслойный прокси.',
+        kicker: '01 / CHAT & PROVIDERS',
+        title: 'Многомодельность и совместимость',
+        body: 'Поддержка OpenAI, Claude, Gemini и любых совместимых API. Ротация ключей, пользовательские параметры и JSON.',
         tags: ['OpenAI', 'Claude', 'Gemini', 'Custom']
       },
       {
-        kicker: '02 / TOOLS',
-        title: 'MCP · Skills · Shortcuts',
-        body:
-          'Единый центр инструментов: MCP-серверы, Agent Skills, iOS Shortcuts, встроенные. Включение по сессии, политика одобрения, отладка потока.',
-        tags: ['MCP', 'Skills', 'Shortcuts', 'Approval']
+        kicker: '02 / LOCAL GGUF',
+        title: 'Локальные GGUF модели и HUD',
+        body: 'Прямой запуск весов GGUF на iOS через llama.cpp C ABI. Ускорение Metal GPU, Flash Attention и плавающий HUD.',
+        tags: ['llama.cpp', 'GGUF', 'Metal GPU', 'HUD']
       },
       {
-        kicker: '03 / MEMORY',
-        title: 'Долгая память · Worldbook · Профиль',
-        body:
-          'Факты между сессиями, записи Worldbook по триггерам, читаемый моделью профиль. Локальный векторный индекс, оффлайн, интеграция с Daily Pulse.',
-        tags: ['Память', 'Worldbook', 'Local RAG']
+        kicker: '03 / TOOLS & SKILLS',
+        title: 'Протокол MCP · Agent Skills · JS',
+        body: 'Единый центр управления MCP серверами, пакетами Agent Skills, Shortcuts и локальными инструментами.',
+        tags: ['MCP SDK', 'Agent Skills', 'Shortcuts']
       },
       {
-        kicker: '04 / DAILY PULSE',
-        title: 'Не пассивные ответы — проактивные карточки',
-        body:
-          'Карточки по вашему расписанию: новости, напоминания о почте, подготовка к встречам, технологические дайджесты. Watch показывает при поднятии руки.',
-        tags: ['Расписание', 'Карточки', 'Raise to view']
+        kicker: '04 / RAG & WORLDBOOK',
+        title: 'Локальная память RAG и Worldbook',
+        body: 'Долгосрочные факты, совместимый с SillyTavern Worldbook (Lorebook) и векторный индекс в SQLite.',
+        tags: ['Memory', 'Worldbook', 'SQLite']
       },
       {
-        kicker: '05 / SYNC',
-        title: 'iPhone ↔ Watch по локальной сети',
-        body:
-          'Без сервера, без iCloud (если сами не захотите). P2P через WatchConnectivity. SQLCipher шифрует всё. Можно унести ETOS-пакет с собой.',
-        tags: ['WatchConnectivity', 'SQLCipher', 'ETOS-пакет']
+        kicker: '05 / DAILY PULSE',
+        title: 'Daily Pulse — активная аналитика',
+        body: 'Ежедневная генерация карточек новостей и задач с обучением по отзывам и просмотром на Apple Watch.',
+        tags: ['Scheduled', 'Cards', 'Watch']
       },
       {
-        kicker: '06 / WATCH',
-        title: 'Полный опыт на запястье, а не урезанный.',
-        body:
-          'Зум Digital Crown, Markdown и подсветка кода, таймлайн размышлений, TTS, кросс-устройство. Настройки watchOS — один плоский List.',
-        tags: ['watchOS', 'Digital Crown', 'Голос']
+        kicker: '06 / WATCH & SYNC',
+        title: 'Синхронизация iPhone ↔ Watch',
+        body: 'Прямой канал WatchConnectivity и CloudKit с генераторными указателями и защитой от конфликтов.',
+        tags: ['WatchConnectivity', 'CloudKit']
+      },
+      {
+        kicker: '07 / WATCH NATIVE',
+        title: 'Полноценный опыт на запястье',
+        body: 'Зум с Digital Crown, подсветка кода, таймлайн размышлений и озвучка TTS.',
+        tags: ['watchOS', 'Digital Crown', 'Voice']
+      },
+      {
+        kicker: '08 / SECURITY & BACKUP',
+        title: 'Шифрование SQLCipher и бэкапы',
+        body: 'Физическое шифрование SQLCipher, защита Face ID, зашифрованные `.elsbackup` и бэкапы в S3 / Cloudflare R2.',
+        tags: ['SQLCipher', 'Face ID', 'S3/R2']
       }
     ]
   },
   screenshots: {
-    title: 'Как это выглядит в руках.',
+    title: 'Как это выглядит в действии.',
     lead: 'Скриншоты из текущей сборки.',
-    captionOne: 'iOS · Чат',
-    captionTwo: 'Apple Watch · Сессия'
+    captionOne: 'iOS · Чат и панели',
+    captionTwo: 'Apple Watch · Экран сессии'
   },
   privacy: {
-    title: 'Ваш ключ. Ваши данные. Ваше устройство.',
-    lead:
-      'ETOS не держит собственного сервера. Запрос уходит с устройства напрямую в модель. Чаты в локальной SQLite (SQLCipher). Синхронизация — по локальной сети между iPhone и Watch. CloudKit или сторонние сервисы — только если сами выберете.',
+    title: 'Ваши ключи. Ваши данные. Ваше устройство.',
+    lead: 'Никаких промежуточных серверов. Запросы отправляются напрямую с устройства, чаты хранятся в локальном SQLCipher.',
     bullets: [
-      { kicker: 'BYOK', title: 'Ключ — ваш', body: 'Мы не проксируем, не кэшируем, не списываем за запросы.' },
-      { kicker: 'LOCAL FIRST', title: 'Чаты на устройстве', body: 'Шифрование SQLCipher + блокировка по Face ID.' },
-      { kicker: 'EXPORTABLE', title: 'ETOS-пакет с собой', body: 'Экспорт/импорт одной кнопкой при переезде.' },
-      { kicker: 'OPEN SOURCE', title: 'GPLv3, проверяемо', body: 'Код открыт. PR и issue — приветствуются.' }
+      { kicker: 'BYOK', title: 'Свой API ключ', body: 'Мы не проксируем и не кэшируем ваши запросы.' },
+      { kicker: 'LOCAL FIRST', title: 'Шифрование на устройстве', body: 'База данных SQLCipher + блокировка Face ID.' },
+      { kicker: 'EXPORTABLE', title: 'Экспорт данных', body: 'Экспорт `.elsbackup` в один клик для легкого переноса.' },
+      { kicker: 'OPEN SOURCE', title: 'Лицензия GPLv3', body: 'Открытый исходный код для полного аудита.' }
     ]
   },
   tech: {
-    title: 'Нативные инструменты — нативный отклик.',
-    lead: 'Без Electron, без React Native, без оболочек WebView.',
+    title: 'Нативные инструменты для нативной скорости.',
+    lead: 'Без Electron. Без React Native. Без WebView.',
     items: [
-      { name: 'Swift 6 · SwiftUI', desc: 'iOS 18 + watchOS 11, следуя Apple HIG.' },
-      { name: 'GRDB · SQLCipher', desc: 'Шифрованная SQLite + реактивные наблюдения.' },
-      { name: 'WatchConnectivity', desc: 'Низкая задержка. Без сервера-посредника.' },
-      { name: 'Background Tasks', desc: 'Daily Pulse рендерится в фоне.' },
-      { name: 'SF Symbols 6', desc: 'Визуально согласовано с системой.' },
-      { name: 'App Intents', desc: 'Глубокая интеграция Siri и Spotlight.' }
+      { name: 'Swift 6 · SwiftUI', desc: 'Нативный UI для iOS 18 и watchOS 11.' },
+      { name: 'llama.cpp C ABI', desc: 'Запуск GGUF весов с Metal GPU на iOS.' },
+      { name: 'Swift MCP SDK', desc: 'Официальный SDK Model Context Protocol.' },
+      { name: 'GRDB · SQLCipher', desc: 'Зашифрованный SQLite с реактивными запросами.' },
+      { name: 'WatchConnectivity & CloudKit', desc: 'Низколатентная синхронизация без серверов.' },
+      { name: 'SFSpeechRecognizer & TTS', desc: 'Распознавание и озвучка речи с фоллбэком.' }
     ]
   },
   cta: {
-    title: 'Первый чат за десять минут.',
-    lead: 'От установки до первого ответа — каждый шаг подскажет, куда нажать.',
-    primary: 'Краткое руководство',
-    secondary: 'GitHub',
-    secondaryDesc: 'Star, issues и PR приветствуются.'
+    title: 'Первый чат за 10 минут.',
+    lead: 'Простые инструкции от установки до первого ответа.',
+    primary: 'Быстрый старт',
+    secondary: 'Код на GitHub',
+    secondaryDesc: 'Star, issue и PR приветствуются.'
   },
   footer: {
-    madeBy: 'С заботой собрано',
+    madeBy: 'Made with care by',
     author: 'Eric-Terminal',
-    license: 'GPL-3.0',
+    license: 'GPL-3.0 License',
     repo: 'github.com/Eric-Terminal/ETOS-LLM-Studio',
     docs: 'Документация',
     backToTop: 'Наверх'
@@ -577,37 +695,57 @@ const ru = {
   },
   ui: {
     theme: { light: 'Светлая', dark: 'Тёмная' },
-    langHint: 'Выберите удобный язык.'
+    langHint: 'Выберите язык.'
   }
 };
 
 const zhHant = {
   meta: {
-    title: 'ETOS LLM Studio',
-    subtitle: 'iPhone + Apple Watch 原生 AI 客戶端'
+    title: 'ETOS LLM Studio · 原生 AI 客戶端',
+    subtitle: 'iPhone + Apple Watch 原生 AI 客戶端 · 端側 LLM 與全能工具中心'
   },
   nav: {
-    features: '功能',
-    personalize: '個人化',
-    privacy: '隱私',
-    tech: '技術',
-    docs: '文件',
+    localModel: '端側 LLM',
+    features: '功能矩陣',
+    mcpSkills: '工具與技能',
+    personalize: '個性化',
+    privacy: '隱私與安全',
+    tech: '技術棧',
+    docs: '文檔',
     github: 'GitHub',
-    download: '取得 App'
+    download: '獲取 App'
   },
   hero: {
-    title: '把 AI 放進口袋，也放上手腕。',
+    title: '你的 AI，揣在手裡，戴在腕上。',
     lead:
-      '一個跑在 iPhone 與 Apple Watch 上的原生 LLM 客戶端。你的 Key、你的資料，從裝置直接送往模型，沒有中介伺服器。',
-    actionsPrimary: '閱讀入門教學',
-    actionsSecondary: '查看功能模組',
-    statusOnline: '持續開發中',
+      '運行在 iPhone 與 Apple Watch 上的原生 LLM 客戶端。支援 GGUF 端側本地模型、MCP 工具協議、Agent Skills 與 SQLCipher 物理加密。你的 Key、你的數據，零中間伺服器。',
+    actionsPrimary: '輕鬆上手教程',
+    actionsSecondary: '探索功能模組',
+    statusOnline: '持續迭代中 · 750+ Swift 源檔案',
     statusBadge: 'BUILT FOR APPLE PLATFORMS'
+  },
+  stats: [
+    { label: 'Swift 源檔案', val: '750+' },
+    { label: '原生 Swift 代碼行', val: '280,000+' },
+    { label: '中間伺服器', val: '0' },
+    { label: '隱私與物理加密', val: '100% Local' }
+  ],
+  localDemo: {
+    badge: '端側本地模型',
+    title: 'iOS 端側硬核 GGUF 本地模型推理',
+    lead: '不需要連接任何網路或 API 服務。底層通過 llama.cpp C ABI 橋接，直接在 iPhone 上加載 GGUF 權重，並提供實時 CPU / Metal / 記憶體性能監視器。',
+    selectModelLabel: '選擇本地 GGUF 模型',
+    thinkHeader: '本地模型思考時間線 (Thinking Timeline)'
+  },
+  mcpSkillsSection: {
+    badge: '工具與生態',
+    title: 'MCP 協議 · Agent Skills · 沙盒 JS',
+    lead: '集成 Swift Model Context Protocol (MCP) 官方 SDK，支援從 GitHub 一鍵導入 Agent Skills 技能包，並可在沙盒內運行自定義 JavaScript 工具。'
   },
   personalize: {
     title: '一眼認得出，是你的 Studio。',
-    lead: '上傳一張壁紙、挑一個對話框顏色、要不要 AI 氣泡——右邊這台即時跟著變。',
-    pickerHint: '調下面三項，右側即時預覽',
+    lead: '上傳一張桌布、挑一個對話框顏色、要不要 AI 氣泡——右邊這台實時跟著變。',
+    pickerHint: '調下面三項，右側實時預覽',
     wallpaperLabel: '背景圖層',
     wallpaperAction: '選擇背景圖',
     colorLabel: '顏色配置',
@@ -616,100 +754,114 @@ const zhHant = {
     chat: {
       title: '問候與幫助',
       user: '你好',
-      bot: '你好！👋\n很高興見到你，有什麼想聊的或者需要幫忙的嗎？無論是圖片處理、海報設計、提示詞編寫、角色設定，還是其他問題，都可以直接告訴我。',
+      bot: '你好！👋\n很高興見到你，有什麼想聊的或者需要幫忙的嗎？無論是端側 GGUF 調參、MCP 工具配置、Agent Skills 導入，還是日常問答，都可以直接告訴我。',
       placeholder: '輸入訊息…'
     }
   },
   features: {
     title: '不是套殼。是把模型當 Apple 平台公民來設計。',
-    lead: '主畫面只留聊天，其餘全部收進設定。下面這些是你裝好之後會慢慢找到的能力。',
+    lead: '主界面只留聊天，其餘全部收進設定。下面這些是你裝好之後會陸續找到的能力。',
     items: [
       {
-        kicker: '01 / CHAT',
-        title: '多模型 · 多 Provider · 相容到底',
+        kicker: '01 / CHAT & PROVIDERS',
+        title: '多模型 · 多 Provider · 兼容到底',
         body:
-          '原生支援 OpenAI Chat、OpenAI Responses、Anthropic、Gemini，外加任意 OpenAI 相容介面。支援多 Key 輪詢、參數表達式、原始 JSON 請求體、提供商 / 全域兩層代理。',
-        tags: ['OpenAI', 'Claude', 'Gemini', 'Custom']
+          '原生適配 OpenAI Chat、OpenAI Responses、Anthropic、Gemini，外加任意 OpenAI 兼容介面。支援多 Key 輪詢、參數表達式、原始 JSON 請求體、單條 AI 回覆重寫與計費估算。',
+        tags: ['OpenAI', 'Claude', 'Gemini', 'Custom JSON']
       },
       {
-        kicker: '02 / TOOLS',
-        title: 'MCP · Skills · 捷徑',
+        kicker: '02 / LOCAL GGUF',
+        title: '端側 GGUF 本地模型 & 性能監視器',
         body:
-          '工具中心統一管理 MCP 伺服器、Agent Skills、iOS 捷徑與內建工具。支援會話級啟用、審批策略、串流除錯與工具時間線。',
-        tags: ['MCP', 'Skills', 'Shortcuts', '審批']
+          '底層通過 llama.cpp C ABI 橋接，在 iOS 上直接運行 GGUF 本地權重。支援 Metal GPU 加速、Flash Attention、KV offload、流式思考解析與浮動性能監視面板（CPU/Metal/RAM）。',
+        tags: ['llama.cpp', 'GGUF', 'Metal GPU', '性能 HUD']
       },
       {
-        kicker: '03 / MEMORY',
-        title: '長期記憶 · 世界書 · 使用者畫像',
+        kicker: '03 / TOOLS & SKILLS',
+        title: 'MCP 協議 · Agent Skills · 沙盒 JS',
         body:
-          '跨會話的事實記憶、關鍵字觸發的世界書條目、模型可讀的使用者畫像。本地向量索引，離線可用，可與 Daily Pulse 串接。',
-        tags: ['長期記憶', '世界書', '本地 RAG']
+          '統一管理 MCP 伺服器（Streamable HTTP/SSE）、Agent Skills 技能包（GitHub/RAW 導入）、iOS 快捷指令與內建 SQLite/檔案沙盒/健康/日曆工具，具備原生問答 Sheet 審批控制。',
+        tags: ['MCP SDK', 'Agent Skills', 'Shortcuts', '審批 Sheet']
       },
       {
-        kicker: '04 / DAILY PULSE',
-        title: '主動情報，不是被動問答',
+        kicker: '04 / RAG & WORLDBOOK',
+        title: '本地 RAG 記憶 · 世界書 · 嵌入向量',
         body:
-          '依你設定的節奏自動生成情報卡片：新聞、郵件提醒、行程預判、技術摘要。Watch 在抬腕時顯示，錯過的可在 iPhone 端回看。',
-        tags: ['排程', '情報卡片', '抬腕']
+          '跨會話長期事實記憶、支援 SillyTavern 兼容的世界書 Lorebook（條件觸發、注入預算）與用戶畫像。向量索引完全本地 SQLite 運行，絕不下發雲端。',
+        tags: ['長期記憶', '世界書 Lorebook', 'SQLite 向量']
       },
       {
-        kicker: '05 / SYNC',
-        title: 'iPhone ↔ Watch 區網直連同步',
+        kicker: '05 / DAILY PULSE',
+        title: 'Daily Pulse 每日脈衝主動情報',
         body:
-          '不走伺服器、不走 iCloud（除非你願意）。雙端透過 WatchConnectivity 與本地點對點協定互傳，SQLCipher 全盤加密，可隨時匯出 ETOS 資料包搬家。',
-        tags: ['WatchConnectivity', 'SQLCipher', 'ETOS 資料包']
+          '每天定時預生成主動情報卡片：新聞、郵件提醒、日程預判、技術摘要。支援卡片一鍵轉待跟進任務與長效偏好反饋學習，抬腕即看。',
+        tags: ['定時', '情報卡片', '任務跟進', 'Watch 抬腕']
       },
       {
-        kicker: '06 / WATCH',
-        title: '手腕上的完整體驗，而不是閹割版。',
+        kicker: '06 / WATCH & SYNC',
+        title: 'iPhone ↔ Watch 權威增量同步',
         body:
-          '數位錶冠縮放圖片、Markdown 與程式碼高亮、思考時間線、TTS 朗讀、跨端發送。watchOS 設定攤平為單層 List，沒有 TabView。',
-        tags: ['watchOS', '數位錶冠', '語音']
+          'WatchConnectivity 局域網快速通道 + CloudKit / APNs 後台漫遊。雙端配備權威世代指針與數據覆蓋衝突裁決短語，離線分叉合併零丟失。',
+        tags: ['WatchConnectivity', 'CloudKit', '世代指針']
+      },
+      {
+        kicker: '07 / WATCH NATIVE',
+        title: '手腕上的完整體驗，不是醃割版',
+        body:
+          '數碼錶冠縮放圖片、Markdown 與代碼高亮、思考時間線、TTS 朗讀、單會話跨端發送。watchOS 設定扁平化為單層 List，零 TabView。',
+        tags: ['watchOS', '數碼錶冠', '抬腕語音', 'TTS']
+      },
+      {
+        kicker: '08 / SECURITY & BACKUP',
+        title: 'SQLCipher 全盤加密 & 快照備份',
+        body:
+          '底層數據庫採用 SQLCipher 物理加密，結合 PBKDF2 主密碼與 Face ID / Touch ID 應用鎖。支援加密快照 `.elsbackup` 導出及 Cloudflare R2 / S3 簽名雲備份。',
+        tags: ['SQLCipher', 'Face ID 鎖', 'AES-256', 'S3/R2 雲備份']
       }
     ]
   },
   screenshots: {
     title: '看看它在你手裡是什麼樣。',
-    lead: '截圖直接來自目前版本。',
-    captionOne: 'iOS · 聊天主畫面',
-    captionTwo: 'Apple Watch · 單會話回看'
+    lead: '截圖直接來自當前真實 Build。',
+    captionOne: 'iOS · 聊天與功能面板',
+    captionTwo: 'Apple Watch · 獨立端側體驗'
   },
   privacy: {
-    title: '你的 Key，你的資料，你的裝置。',
+    title: '你的 Key，你的數據，你的設備。',
     lead:
-      'ETOS LLM Studio 不營運任何中介伺服器。模型請求從你的裝置直接送出，會話存在本機 SQLite（SQLCipher 加密），同步透過 iPhone 與 Watch 在區網內完成。要不要上 CloudKit、要不要交給第三方，全由你決定。',
+      '沒有任何中間伺服器。模型請求從你的設備直接發出，對話存在本地 SQLite（SQLCipher 加密），同步通過 iPhone 與 Watch 在局域網或 CloudKit 完成。要不要交給第三方，全是你的選擇。',
     bullets: [
-      { kicker: 'BYOK', title: '你提供 Key，App 直送模型', body: '我們不代付、不轉發、不快取你的請求。' },
-      { kicker: 'LOCAL FIRST', title: '會話與記憶存在本機', body: 'SQLCipher 全盤加密，可應用鎖 + Face ID 雙重門。' },
-      { kicker: 'EXPORTABLE', title: 'ETOS 資料包，隨時帶走', body: '一鍵匯出/匯入，搬家不成問題。' },
-      { kicker: 'OPEN SOURCE', title: 'GPLv3 開源', body: '程式碼可審計，PR 與 Issue 都歡迎。' }
+      { kicker: 'BYOK', title: '你提供 Key，App 直發模型', body: '我們不代付、不轉發、不快取你的請求。' },
+      { kicker: 'LOCAL FIRST', title: '會話與記憶存在本地', body: 'SQLCipher 全盤加密，配合 Face ID 應用鎖。' },
+      { kicker: 'EXPORTABLE', title: 'ETOS 數據包與加密快照', body: '一鍵導出/導入 `.elsbackup`，跨端遷移無痛。' },
+      { kicker: 'OPEN SOURCE', title: 'GPLv3 開源', body: '代碼完全公開可審計，歡迎 PR 與 Issue。' }
     ]
   },
   tech: {
     title: '用原生工具，做原生體驗。',
-    lead: '沒有 Electron，沒有 React Native，沒有 WebView 套殼。',
+    lead: '沒有 Electron，沒有 React Native，沒有 WebView 套殼。快速，性能超強。',
     items: [
       { name: 'Swift 6 · SwiftUI', desc: 'iOS 18 + watchOS 11 原生 UI，遵循 Apple HIG。' },
-      { name: 'GRDB · SQLCipher', desc: '加密 SQLite + ValueObservation 響應式查詢。' },
-      { name: 'WatchConnectivity', desc: '雙端低延遲同步，無中介伺服器。' },
-      { name: 'Background Tasks', desc: 'Daily Pulse 在背景預先生成。' },
-      { name: 'SF Symbols 6', desc: '原生圖示體系，與系統視覺一致。' },
-      { name: 'App Intents', desc: 'Siri 捷徑與 Spotlight 深度整合。' }
+      { name: 'llama.cpp C ABI', desc: 'iOS 端側運行 GGUF 權重，Metal GPU 加速與性能 HUD。' },
+      { name: 'Swift MCP SDK', desc: 'Model Context Protocol 官方 SDK，支援 SSE / Streamable HTTP。' },
+      { name: 'GRDB · SQLCipher', desc: '物理全盤加密 SQLite + ValueObservation 響應式查詢。' },
+      { name: 'WatchConnectivity & CloudKit', desc: '雙端低延遲增量同步，帶世代指針與 APNs 靜默喚醒。' },
+      { name: 'SFSpeechRecognizer & TTS', desc: '系統與雲端語音識別及朗讀引擎，實時回填與自動回退。' }
     ]
   },
   cta: {
     title: '十分鐘跑通第一條對話。',
-    lead: '裝機、設定 Provider、第一條訊息，每一步都告訴你點哪裡。',
-    primary: '閱讀入門教學',
+    lead: '裝機、配 Provider、第一條訊息，每一步都告訴你點哪裡。',
+    primary: '閱讀上手教程',
     secondary: 'GitHub 原始碼',
     secondaryDesc: '歡迎 Star、Issue、PR。'
   },
   footer: {
     madeBy: 'Made with care by',
     author: 'Eric-Terminal',
-    license: 'GPL-3.0 授權',
+    license: 'GPL-3.0 License',
     repo: 'github.com/Eric-Terminal/ETOS-LLM-Studio',
-    docs: '文件站',
+    docs: '文檔站',
     backToTop: '回到頂部'
   },
   loader: {
@@ -719,7 +871,7 @@ const zhHant = {
   },
   ui: {
     theme: { light: '淺色', dark: '深色' },
-    langHint: '選擇你慣用的語言。'
+    langHint: '選擇你順手的語言。'
   }
 };
 

--- a/docs/landing/src/i18n.js
+++ b/docs/landing/src/i18n.js
@@ -48,11 +48,20 @@ const zh = {
     badge: '端侧本地模型',
     title: 'iOS 端侧硬核 GGUF 本地模型推理',
     lead: '不需要连接任何网络或 API 服务。底层通过 llama.cpp C ABI 桥接，直接在 iPhone 上加载 GGUF 权重，并提供实时 CPU / Metal / 内存性能监视器。',
+    controlBadge: 'GGUF · llama.cpp C ABI',
     selectModelLabel: '选择本地 GGUF 模型',
+    metalOffloadLabel: 'Metal GPU 卸载',
+    flashAttentionLabel: 'Flash Attention',
+    kvCacheLabel: 'KV Cache 前缀复用',
+    cpuLoadLabel: 'CPU 负载',
+    metalGPULabel: 'METAL GPU',
+    memoryLabel: '内存',
+    speedLabel: '推理速度',
+    estimateDisclaimer: '演示数据为估算示例；实际性能取决于设备、量化方式和上下文长度。',
     thinkHeader: '本地模型思考时间线 (Thinking Timeline)',
     userQuestion: '运行端侧 GGUF 本地模型需要连接网络或 API Key 吗？',
-    kvCacheActiveLabel: 'KV Cache 前缀复用已生效',
-    kvCacheInactiveLabel: 'KV Cache 未开启',
+    kvCacheEnabledLabel: 'KV Cache 前缀复用已启用',
+    kvCacheDisabledLabel: 'KV Cache 前缀复用未启用',
     models: [
       {
         name: 'Phi-4-mini-Instruct.Q4_K_M.gguf',
@@ -66,12 +75,10 @@ const zh = {
           ramCpu: '3.1 GB (RAM)',
           ramCpuKV: '3.4 GB (RAM + KV)',
           speedFlash: 49.6,
-          speedFlashKV: 57.8,
-          speedBase: 29.8,
-          speedKV: 34.2
+          speedBase: 29.8
         },
-        thinking: '正在使用 Metal GPU 加速计算，分析对话上下文与 GGUF Jinja 对话模板...',
-        response: '完全不需要网络或 API Key！模型权重与 Embedding 嵌入向量数据库完全运行在你的 iPhone 本机设备上。零联网权限，不消耗流量，隐私 100% 物理隔离。'
+        thinking: '正在解析本地对话上下文与 GGUF Jinja 对话模板...',
+        response: '本地模型推理不需要网络或 API Key，模型权重与生成过程都留在设备上；只有主动使用联网模型或网络工具时才会发起网络请求。'
       },
       {
         name: 'Gemma-3-4B-Instruct.Q4_K_M.gguf',
@@ -85,12 +92,10 @@ const zh = {
           ramCpu: '3.7 GB (RAM)',
           ramCpuKV: '4.1 GB (RAM + KV)',
           speedFlash: 38.0,
-          speedFlashKV: 44.3,
-          speedBase: 23.2,
-          speedKV: 26.8
+          speedBase: 23.2
         },
-        thinking: 'Checking local GGUF memory budget and Metal GPU offload layers...',
-        response: 'Gemma 3 4B 本地推理完成！全流式 Metal GPU 加速输出与 KV Cache 前缀复用正常，内存占用按上下文缓存同步增加。'
+        thinking: '正在检查本地 GGUF 上下文预算与对话模板...',
+        response: 'Gemma 3 4B 本地推理演示完成。上方 HUD 会根据所选运行选项展示对应的估算数据。'
       },
       {
         name: 'Qwen3-8B-Instruct.Q4_K_M.gguf',
@@ -104,12 +109,10 @@ const zh = {
           ramCpu: '6.1 GB (RAM)',
           ramCpuKV: '6.8 GB (RAM + KV)',
           speedFlash: 26.4,
-          speedFlashKV: 30.5,
-          speedBase: 15.7,
-          speedKV: 18.2
+          speedBase: 15.7
         },
-        thinking: '正在解析 <think> 推理链：1. 检索本地 SQLite 数据库；2. 匹配 KV Cache 缓存前缀；3. 生成结构化思考步骤...',
-        response: 'Qwen3 8B 本地推理完成！全流式 Metal GPU 加速输出与 KV Cache 前缀复用正常，吞吐与内存占用按 8B 模型规模显示。'
+        thinking: '正在解析 <think> 推理链：1. 读取本地上下文；2. 应用对话模板；3. 生成结构化思考步骤...',
+        response: 'Qwen3 8B 本地推理演示完成。HUD 按 8B 模型规模和当前选项展示吞吐与内存估算。'
       }
     ]
   },
@@ -117,17 +120,26 @@ const zh = {
     badge: '工具与生态',
     title: 'MCP 协议 · Agent Skills · 沙盒 JS',
     lead: '集成 Swift Model Context Protocol (MCP) 官方 SDK，支持从 GitHub 一键导入 Agent Skills 技能包，并可在沙盒内运行自定义 JavaScript 工具。',
+    specLabel: '规格',
     tabs: [
       {
         id: 'mcp',
-        type: 'BUILT-IN APP TOOL',
-        title: '内置系统时间工具',
-        badge: 'Built-in App Tool',
-        desc: '在 AI 想要获取设备时间时，调用内置 App Tool；它不属于外部 MCP 工具，参数为空。',
-        snippet: `// Built-in App Tool Execution
+        type: 'BUILT-IN MCP SERVER',
+        title: '内建数据库 MCP Server',
+        badge: 'Official Swift MCP SDK',
+        desc: 'ETOS 将数据库 App Tool 包装为内建 MCP Server；下面通过标准 tools/call 列出记忆数据库表结构。',
+        snippet: `// builtin://app-tools/database
 {
-  "tool": "app_get_system_time",
-  "arguments": {}
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "app_list_sqlite_tables",
+    "arguments": {
+      "database": "memory",
+      "include_create_sql": true
+    }
+  }
 }`
       },
       {
@@ -167,18 +179,18 @@ function main(input) {
       },
       {
         id: 'rag',
-        type: 'SQLCIPHER RAG',
-        title: 'SQLite 全盘物理加密向量库',
-        badge: 'GRDB + SQLCipher',
-        desc: '本地 Embedding 与长效记忆直接落地在加密 SQLite 数据库中，支持 SillyTavern 世界书触发。',
+        type: 'LOCAL RAG INDEX',
+        title: 'SQLite 本地向量索引',
+        badge: 'SQLite3',
+        desc: '本地 Embedding 索引保存在 memory_vectors.sqlite 的 memory_chunks 表中，并与长期记忆及 SillyTavern 世界书配合使用。',
         snippet: `-- memory_vectors.sqlite
-CREATE TABLE memory_chunks (
+CREATE TABLE IF NOT EXISTS memory_chunks (
   chunk_id TEXT PRIMARY KEY,
   parent_memory_id TEXT NOT NULL,
   text TEXT NOT NULL,
   embedding BLOB NOT NULL,
   metadata TEXT NOT NULL
-) STRICT;`
+);`
       }
     ]
   },
@@ -350,11 +362,20 @@ const en = {
     badge: 'On-Device Local Model',
     title: 'Native GGUF Inference & Performance HUD on iOS',
     lead: 'No network or API keys needed. Bridged via llama.cpp C ABI directly on iOS with Metal GPU acceleration and real-time CPU / Metal / Memory telemetry.',
+    controlBadge: 'GGUF · llama.cpp C ABI',
     selectModelLabel: 'Select Local GGUF Model',
+    metalOffloadLabel: 'Metal GPU Offload',
+    flashAttentionLabel: 'Flash Attention',
+    kvCacheLabel: 'KV Cache Prefix Reuse',
+    cpuLoadLabel: 'CPU LOAD',
+    metalGPULabel: 'METAL GPU',
+    memoryLabel: 'MEMORY',
+    speedLabel: 'INFERENCE SPEED',
+    estimateDisclaimer: 'Demo values are estimates; actual performance depends on the device, quantization, and context length.',
     thinkHeader: 'Thinking Timeline',
     userQuestion: 'Does running on-device GGUF models require network or API keys?',
-    kvCacheActiveLabel: 'KV Cache Prefix Reuse Active',
-    kvCacheInactiveLabel: 'KV Cache Disabled',
+    kvCacheEnabledLabel: 'KV Cache Prefix Reuse Enabled',
+    kvCacheDisabledLabel: 'KV Cache Prefix Reuse Disabled',
     models: [
       {
         name: 'Phi-4-mini-Instruct.Q4_K_M.gguf',
@@ -368,12 +389,10 @@ const en = {
           ramCpu: '3.1 GB (RAM)',
           ramCpuKV: '3.4 GB (RAM + KV)',
           speedFlash: 49.6,
-          speedFlashKV: 57.8,
-          speedBase: 29.8,
-          speedKV: 34.2
+          speedBase: 29.8
         },
-        thinking: 'Accelerating via Metal GPU, analyzing chat context and GGUF Jinja chat template...',
-        response: 'No network or API key required! Model weights and SQLite vector database run 100% locally on your iPhone with zero telemetry.'
+        thinking: 'Parsing the local conversation context and GGUF Jinja chat template...',
+        response: 'Local model inference needs no network or API key. Model weights and generation stay on the device; network access only occurs when you choose an online model or network tool.'
       },
       {
         name: 'Gemma-3-4B-Instruct.Q4_K_M.gguf',
@@ -387,12 +406,10 @@ const en = {
           ramCpu: '3.7 GB (RAM)',
           ramCpuKV: '4.1 GB (RAM + KV)',
           speedFlash: 38.0,
-          speedFlashKV: 44.3,
-          speedBase: 23.2,
-          speedKV: 26.8
+          speedBase: 23.2
         },
-        thinking: 'Checking local GGUF memory budget and Metal GPU offload layers...',
-        response: 'Gemma 3 4B local execution complete. Metal streaming and KV prefix reuse are active, with memory increasing to reflect the cached context.'
+        thinking: 'Checking the local GGUF context budget and chat template...',
+        response: 'Gemma 3 4B local inference demo complete. The HUD above shows estimates for the selected runtime options.'
       },
       {
         name: 'Qwen3-8B-Instruct.Q4_K_M.gguf',
@@ -406,12 +423,10 @@ const en = {
           ramCpu: '6.1 GB (RAM)',
           ramCpuKV: '6.8 GB (RAM + KV)',
           speedFlash: 26.4,
-          speedFlashKV: 30.5,
-          speedBase: 15.7,
-          speedKV: 18.2
+          speedBase: 15.7
         },
-        thinking: 'Parsing <think> reasoning chain: 1. Search local SQLite; 2. Match KV Cache prefix; 3. Generate structured thinking steps...',
-        response: 'Qwen3 8B local inference complete. Metal acceleration and KV reuse are active, with throughput and memory shown at the larger 8B scale.'
+        thinking: 'Parsing the <think> reasoning chain: 1. Read local context; 2. Apply the chat template; 3. Generate structured reasoning steps...',
+        response: 'Qwen3 8B local inference demo complete. The HUD estimates throughput and memory for the 8B model and current options.'
       }
     ]
   },
@@ -419,17 +434,26 @@ const en = {
     badge: 'Tools & Ecosystem',
     title: 'MCP Protocol · Agent Skills · Sandboxed JS',
     lead: 'Official Swift Model Context Protocol SDK, one-click Agent Skill import from GitHub, and sandboxed JavaScript tool runtime.',
+    specLabel: 'SPEC',
     tabs: [
       {
         id: 'mcp',
-        type: 'BUILT-IN APP TOOL',
-        title: 'Built-in System Time Tool',
-        badge: 'Built-in App Tool',
-        desc: 'When AI requests device time, it calls a built-in App Tool. This is not an external MCP tool and takes no arguments.',
-        snippet: `// Built-in App Tool Execution
+        type: 'BUILT-IN MCP SERVER',
+        title: 'Built-in Database MCP Server',
+        badge: 'Official Swift MCP SDK',
+        desc: 'ETOS wraps database App Tools in a built-in MCP server. This standard tools/call request lists tables in the memory database.',
+        snippet: `// builtin://app-tools/database
 {
-  "tool": "app_get_system_time",
-  "arguments": {}
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "app_list_sqlite_tables",
+    "arguments": {
+      "database": "memory",
+      "include_create_sql": true
+    }
+  }
 }`
       },
       {
@@ -469,18 +493,18 @@ function main(input) {
       },
       {
         id: 'rag',
-        type: 'SQLCIPHER RAG',
-        title: 'SQLite Encrypted Vector Store',
-        badge: 'GRDB + SQLCipher',
-        desc: 'Local embeddings and long-term memory stored inside encrypted SQLite database with SillyTavern Worldbook support.',
+        type: 'LOCAL RAG INDEX',
+        title: 'Local SQLite Vector Index',
+        badge: 'SQLite3',
+        desc: 'Local embedding indexes are stored in the memory_chunks table of memory_vectors.sqlite and work with long-term memory and SillyTavern Worldbooks.',
         snippet: `-- memory_vectors.sqlite
-CREATE TABLE memory_chunks (
+CREATE TABLE IF NOT EXISTS memory_chunks (
   chunk_id TEXT PRIMARY KEY,
   parent_memory_id TEXT NOT NULL,
   text TEXT NOT NULL,
   embedding BLOB NOT NULL,
   metadata TEXT NOT NULL
-) STRICT;`
+);`
       }
     ]
   },
@@ -652,11 +676,20 @@ const ja = {
     badge: 'オンデバイスローカルモデル',
     title: 'iOS 上での GGUF 推論 & パフォーマンス HUD',
     lead: 'ネット接続や API キーは一切不要。llama.cpp C ABI 経由で Metal GPU アクセラレーションとリアルタイム CPU/GPU/メモリ モニターを搭載。',
+    controlBadge: 'GGUF · llama.cpp C ABI',
     selectModelLabel: 'ローカル GGUF モデルを選択',
+    metalOffloadLabel: 'Metal GPU オフロード',
+    flashAttentionLabel: 'Flash Attention',
+    kvCacheLabel: 'KV Cache プレフィックス再利用',
+    cpuLoadLabel: 'CPU 負荷',
+    metalGPULabel: 'METAL GPU',
+    memoryLabel: 'メモリ',
+    speedLabel: '推論速度',
+    estimateDisclaimer: '表示値はデモ用の推定値です。実際の性能はデバイス、量子化方式、コンテキスト長によって異なります。',
     thinkHeader: '思考タイムライン (Thinking Timeline)',
     userQuestion: 'ローカル GGUF モデルの実行にネット接続や API キーは必要ですか？',
-    kvCacheActiveLabel: 'KV Cache プレフィックス再利用中',
-    kvCacheInactiveLabel: 'KV Cache 未有効化',
+    kvCacheEnabledLabel: 'KV Cache プレフィックス再利用を有効化',
+    kvCacheDisabledLabel: 'KV Cache プレフィックス再利用を無効化',
     models: [
       {
         name: 'Phi-4-mini-Instruct.Q4_K_M.gguf',
@@ -670,12 +703,10 @@ const ja = {
           ramCpu: '3.1 GB (RAM)',
           ramCpuKV: '3.4 GB (RAM + KV)',
           speedFlash: 49.6,
-          speedFlashKV: 57.8,
-          speedBase: 29.8,
-          speedKV: 34.2
+          speedBase: 29.8
         },
-        thinking: 'Metal GPU 加速で計算中、GGUF Jinja テンプレートを解析中...',
-        response: 'ネット接続や API キーは一切不要です！モデルウェイトと SQLite ベクトル DB は端末内で 100% ローカル動作します。'
+        thinking: 'ローカルの会話コンテキストと GGUF Jinja テンプレートを解析中...',
+        response: 'ローカルモデル推論にネット接続や API キーは不要です。モデルウェイトと生成処理は端末内に留まり、オンラインモデルやネットワークツールを選んだ場合のみ通信します。'
       },
       {
         name: 'Gemma-3-4B-Instruct.Q4_K_M.gguf',
@@ -689,12 +720,10 @@ const ja = {
           ramCpu: '3.7 GB (RAM)',
           ramCpuKV: '4.1 GB (RAM + KV)',
           speedFlash: 38.0,
-          speedFlashKV: 44.3,
-          speedBase: 23.2,
-          speedKV: 26.8
+          speedBase: 23.2
         },
-        thinking: 'Checking local GGUF memory budget and Metal GPU offload layers...',
-        response: 'Gemma 3 4B ローカル推論完了！Metal GPU 加速と KV Cache 再利用が正常に動作し、キャッシュ分のメモリも反映されています。'
+        thinking: 'ローカル GGUF のコンテキスト予算とチャットテンプレートを確認中...',
+        response: 'Gemma 3 4B のローカル推論デモが完了しました。上の HUD は選択中の実行オプションに基づく推定値です。'
       },
       {
         name: 'Qwen3-8B-Instruct.Q4_K_M.gguf',
@@ -708,12 +737,10 @@ const ja = {
           ramCpu: '6.1 GB (RAM)',
           ramCpuKV: '6.8 GB (RAM + KV)',
           speedFlash: 26.4,
-          speedFlashKV: 30.5,
-          speedBase: 15.7,
-          speedKV: 18.2
+          speedBase: 15.7
         },
-        thinking: '<think> 推論チェーンを解析中: 1. SQLite 検索; 2. KV Cache マッチング; 3. 思考ステップ生成...',
-        response: 'Qwen3 8B ローカル推論完了。8B モデル規模に合わせたスループットとメモリ使用量を表示しています。'
+        thinking: '<think> 推論チェーンを解析中: 1. ローカルコンテキストを読む; 2. チャットテンプレートを適用; 3. 構造化された思考ステップを生成...',
+        response: 'Qwen3 8B のローカル推論デモが完了しました。HUD は 8B モデルと現在のオプションに基づくスループットとメモリの推定値です。'
       }
     ]
   },
@@ -721,17 +748,26 @@ const ja = {
     badge: 'ツールとエコシステム',
     title: 'MCP プロトコル · Agent Skills · Sandboxed JS',
     lead: '公式 Swift MCP SDK、GitHub からのワンクリック Agent Skill インポート、サンドボックス化 JavaScript ランタイムを搭載。',
+    specLabel: '仕様',
     tabs: [
       {
         id: 'mcp',
-        type: 'BUILT-IN APP TOOL',
-        title: '内蔵システム時刻ツール',
-        badge: 'Built-in App Tool',
-        desc: 'AI がデバイス時刻を必要とするときは内蔵 App Tool を呼び出します。外部 MCP ツールではなく、引数も不要です。',
-        snippet: `// Built-in App Tool Execution
+        type: 'BUILT-IN MCP SERVER',
+        title: '内蔵データベース MCP Server',
+        badge: 'Official Swift MCP SDK',
+        desc: 'ETOS はデータベース App Tool を内蔵 MCP Server として公開します。以下の標準 tools/call はメモリデータベースのテーブル一覧を取得します。',
+        snippet: `// builtin://app-tools/database
 {
-  "tool": "app_get_system_time",
-  "arguments": {}
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "app_list_sqlite_tables",
+    "arguments": {
+      "database": "memory",
+      "include_create_sql": true
+    }
+  }
 }`
       },
       {
@@ -771,18 +807,18 @@ function main(input) {
       },
       {
         id: 'rag',
-        type: 'SQLCIPHER RAG',
-        title: 'SQLite 暗号化ベクトルストア',
-        badge: 'GRDB + SQLCipher',
-        desc: '暗号化 SQLite データベース内に長期記憶を保存。SillyTavern ワールドブック対応。',
+        type: 'LOCAL RAG INDEX',
+        title: 'SQLite ローカルベクトルインデックス',
+        badge: 'SQLite3',
+        desc: 'ローカル Embedding インデックスは memory_vectors.sqlite の memory_chunks テーブルに保存され、長期記憶と SillyTavern ワールドブックで利用されます。',
         snippet: `-- memory_vectors.sqlite
-CREATE TABLE memory_chunks (
+CREATE TABLE IF NOT EXISTS memory_chunks (
   chunk_id TEXT PRIMARY KEY,
   parent_memory_id TEXT NOT NULL,
   text TEXT NOT NULL,
   embedding BLOB NOT NULL,
   metadata TEXT NOT NULL
-) STRICT;`
+);`
       }
     ]
   },
@@ -945,11 +981,20 @@ const ru = {
     badge: 'Локальная модель на устройстве',
     title: 'Нативный GGUF инференс и HUD производительности на iOS',
     lead: 'Работает полностью без интернета. Модели GGUF исполняются через C ABI llama.cpp с ускорением Metal GPU и онлайн-монитором CPU/Metal/Памяти.',
+    controlBadge: 'GGUF · llama.cpp C ABI',
     selectModelLabel: 'Выберите модель GGUF',
+    metalOffloadLabel: 'Выгрузка слоёв на Metal GPU',
+    flashAttentionLabel: 'Flash Attention',
+    kvCacheLabel: 'Повторное использование префикса KV Cache',
+    cpuLoadLabel: 'ЗАГРУЗКА CPU',
+    metalGPULabel: 'METAL GPU',
+    memoryLabel: 'ПАМЯТЬ',
+    speedLabel: 'СКОРОСТЬ ИНФЕРЕНСА',
+    estimateDisclaimer: 'Значения приведены для демонстрации. Реальная производительность зависит от устройства, квантования и длины контекста.',
     thinkHeader: 'Таймлайн размышлений (Thinking Timeline)',
     userQuestion: 'Требуется ли интернет или API ключ для локальной модели GGUF?',
-    kvCacheActiveLabel: 'Префикс KV Cache активирован',
-    kvCacheInactiveLabel: 'KV Cache отключен',
+    kvCacheEnabledLabel: 'Повторное использование KV Cache включено',
+    kvCacheDisabledLabel: 'Повторное использование KV Cache отключено',
     models: [
       {
         name: 'Phi-4-mini-Instruct.Q4_K_M.gguf',
@@ -963,12 +1008,10 @@ const ru = {
           ramCpu: '3.1 GB (RAM)',
           ramCpuKV: '3.4 GB (RAM + KV)',
           speedFlash: 49.6,
-          speedFlashKV: 57.8,
-          speedBase: 29.8,
-          speedKV: 34.2
+          speedBase: 29.8
         },
-        thinking: 'Ускорение Metal GPU, анализ контекста чата и шаблона GGUF Jinja...',
-        response: 'Интернет и API ключ не требуются! Веса модели и векторная база SQLite работают 100% локально на вашем iPhone.'
+        thinking: 'Анализ локального контекста диалога и шаблона GGUF Jinja...',
+        response: 'Для локального инференса не нужны интернет и API ключ. Веса модели и генерация остаются на устройстве; сеть используется только при выборе онлайн-модели или сетевого инструмента.'
       },
       {
         name: 'Gemma-3-4B-Instruct.Q4_K_M.gguf',
@@ -982,12 +1025,10 @@ const ru = {
           ramCpu: '3.7 GB (RAM)',
           ramCpuKV: '4.1 GB (RAM + KV)',
           speedFlash: 38.0,
-          speedFlashKV: 44.3,
-          speedBase: 23.2,
-          speedKV: 26.8
+          speedBase: 23.2
         },
-        thinking: 'Checking local GGUF memory budget and Metal GPU offload layers...',
-        response: 'Локальный инференс Gemma 3 4B завершен! Metal GPU и KV Cache активны, а память включает дополнительный контекстный кэш.'
+        thinking: 'Проверка бюджета контекста GGUF и шаблона диалога...',
+        response: 'Демонстрация локального инференса Gemma 3 4B завершена. HUD показывает оценки для выбранных параметров запуска.'
       },
       {
         name: 'Qwen3-8B-Instruct.Q4_K_M.gguf',
@@ -1001,12 +1042,10 @@ const ru = {
           ramCpu: '6.1 GB (RAM)',
           ramCpuKV: '6.8 GB (RAM + KV)',
           speedFlash: 26.4,
-          speedFlashKV: 30.5,
-          speedBase: 15.7,
-          speedKV: 18.2
+          speedBase: 15.7
         },
-        thinking: 'Разбор цепочки <think>: 1. Поиск SQLite; 2. Совпадение KV Cache; 3. Генерация шагов...',
-        response: 'Локальный инференс Qwen3 8B завершен. HUD показывает пропускную способность и память с учетом масштаба 8B модели.'
+        thinking: 'Разбор цепочки <think>: 1. Чтение локального контекста; 2. Применение шаблона диалога; 3. Генерация структурированных шагов...',
+        response: 'Демонстрация локального инференса Qwen3 8B завершена. HUD оценивает скорость и память для модели 8B и текущих параметров.'
       }
     ]
   },
@@ -1014,17 +1053,26 @@ const ru = {
     badge: 'Инструменты и экосистема',
     title: 'Протокол MCP · Agent Skills · Песочница JS',
     lead: 'Официальный Swift MCP SDK, импорт Agent Skills с GitHub в один клик и изолированный запуск JS-скриптов.',
+    specLabel: 'СПЕЦИФИКАЦИЯ',
     tabs: [
       {
         id: 'mcp',
-        type: 'BUILT-IN APP TOOL',
-        title: 'Встроенный инструмент системного времени',
-        badge: 'Built-in App Tool',
-        desc: 'Когда AI требуется время устройства, он вызывает встроенный App Tool. Это не внешний MCP инструмент, и аргументы не нужны.',
-        snippet: `// Built-in App Tool Execution
+        type: 'BUILT-IN MCP SERVER',
+        title: 'Встроенный MCP-сервер базы данных',
+        badge: 'Official Swift MCP SDK',
+        desc: 'ETOS публикует инструменты базы данных через встроенный MCP-сервер. Стандартный запрос tools/call ниже выводит таблицы базы памяти.',
+        snippet: `// builtin://app-tools/database
 {
-  "tool": "app_get_system_time",
-  "arguments": {}
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "app_list_sqlite_tables",
+    "arguments": {
+      "database": "memory",
+      "include_create_sql": true
+    }
+  }
 }`
       },
       {
@@ -1064,18 +1112,18 @@ function main(input) {
       },
       {
         id: 'rag',
-        type: 'SQLCIPHER RAG',
-        title: 'Зашифрованная база SQLite RAG',
-        badge: 'GRDB + SQLCipher',
-        desc: 'Долгосрочная память сохраняется в зашифрованной базе SQLite с поддержкой SillyTavern Worldbook.',
+        type: 'LOCAL RAG INDEX',
+        title: 'Локальный векторный индекс SQLite',
+        badge: 'SQLite3',
+        desc: 'Локальный индекс Embedding хранится в таблице memory_chunks файла memory_vectors.sqlite и используется с долгосрочной памятью и SillyTavern Worldbook.',
         snippet: `-- memory_vectors.sqlite
-CREATE TABLE memory_chunks (
+CREATE TABLE IF NOT EXISTS memory_chunks (
   chunk_id TEXT PRIMARY KEY,
   parent_memory_id TEXT NOT NULL,
   text TEXT NOT NULL,
   embedding BLOB NOT NULL,
   metadata TEXT NOT NULL
-) STRICT;`
+);`
       }
     ]
   },
@@ -1238,11 +1286,20 @@ const zhHant = {
     badge: '端側本地模型',
     title: 'iOS 端側硬核 GGUF 本地模型推理',
     lead: '不需要連接任何網路或 API 服務。底層通過 llama.cpp C ABI 橋接，直接在 iPhone 上加載 GGUF 權重，並提供實時 CPU / Metal / 記憶體性能監視器。',
+    controlBadge: 'GGUF · llama.cpp C ABI',
     selectModelLabel: '選擇本地 GGUF 模型',
+    metalOffloadLabel: 'Metal GPU 卸載',
+    flashAttentionLabel: 'Flash Attention',
+    kvCacheLabel: 'KV Cache 前綴複用',
+    cpuLoadLabel: 'CPU 負載',
+    metalGPULabel: 'METAL GPU',
+    memoryLabel: '記憶體',
+    speedLabel: '推理速度',
+    estimateDisclaimer: '演示數據為估算示例；實際性能取決於裝置、量化方式和上下文長度。',
     thinkHeader: '本地模型思考時間線 (Thinking Timeline)',
     userQuestion: '運行端側 GGUF 本地模型需要連接網路或 API Key 嗎？',
-    kvCacheActiveLabel: 'KV Cache 前綴複用已生效',
-    kvCacheInactiveLabel: 'KV Cache 未開啟',
+    kvCacheEnabledLabel: 'KV Cache 前綴複用已啟用',
+    kvCacheDisabledLabel: 'KV Cache 前綴複用未啟用',
     models: [
       {
         name: 'Phi-4-mini-Instruct.Q4_K_M.gguf',
@@ -1256,12 +1313,10 @@ const zhHant = {
           ramCpu: '3.1 GB (RAM)',
           ramCpuKV: '3.4 GB (RAM + KV)',
           speedFlash: 49.6,
-          speedFlashKV: 57.8,
-          speedBase: 29.8,
-          speedKV: 34.2
+          speedBase: 29.8
         },
-        thinking: '正在使用 Metal GPU 加速計算，分析對話上下文與 GGUF Jinja 對話模板...',
-        response: '完全不需要網路或 API Key！模型權重與 Embedding 嵌入向量數據庫完全運行在你的 iPhone 本機設備上。零聯網權限，不消耗流量，隱私 100% 物理隔離。'
+        thinking: '正在解析本地對話上下文與 GGUF Jinja 對話模板...',
+        response: '本地模型推理不需要網路或 API Key，模型權重與生成過程都留在裝置上；只有主動使用聯網模型或網路工具時才會發起網路請求。'
       },
       {
         name: 'Gemma-3-4B-Instruct.Q4_K_M.gguf',
@@ -1275,12 +1330,10 @@ const zhHant = {
           ramCpu: '3.7 GB (RAM)',
           ramCpuKV: '4.1 GB (RAM + KV)',
           speedFlash: 38.0,
-          speedFlashKV: 44.3,
-          speedBase: 23.2,
-          speedKV: 26.8
+          speedBase: 23.2
         },
-        thinking: 'Checking local GGUF memory budget and Metal GPU offload layers...',
-        response: 'Gemma 3 4B 本地推理完成！全流式 Metal GPU 加速輸出與 KV Cache 快取前綴複用正常，記憶體佔用會隨上下文快取同步增加。'
+        thinking: '正在檢查本地 GGUF 上下文預算與對話模板...',
+        response: 'Gemma 3 4B 本地推理演示完成。上方 HUD 會根據所選運行選項展示對應的估算數據。'
       },
       {
         name: 'Qwen3-8B-Instruct.Q4_K_M.gguf',
@@ -1294,12 +1347,10 @@ const zhHant = {
           ramCpu: '6.1 GB (RAM)',
           ramCpuKV: '6.8 GB (RAM + KV)',
           speedFlash: 26.4,
-          speedFlashKV: 30.5,
-          speedBase: 15.7,
-          speedKV: 18.2
+          speedBase: 15.7
         },
-        thinking: '正在解析 <think> 推理鏈：1. 檢索本地 SQLite 數據庫；2. 匹配 KV Cache 快取前綴；3. 生成結構化思考步驟...',
-        response: 'Qwen3 8B 本地推理完成！全流式 Metal GPU 加速輸出與 KV Cache 快取前綴複用正常，吞吐與記憶體佔用按 8B 模型規模顯示。'
+        thinking: '正在解析 <think> 推理鏈：1. 讀取本地上下文；2. 套用對話模板；3. 生成結構化思考步驟...',
+        response: 'Qwen3 8B 本地推理演示完成。HUD 按 8B 模型規模和目前選項展示吞吐與記憶體估算。'
       }
     ]
   },
@@ -1307,17 +1358,26 @@ const zhHant = {
     badge: '工具與生態',
     title: 'MCP 協議 · Agent Skills · 沙盒 JS',
     lead: '集成 Swift Model Context Protocol (MCP) 官方 SDK，支援從 GitHub 一鍵導入 Agent Skills 技能包，並可在沙盒內運行自定義 JavaScript 工具。',
+    specLabel: '規格',
     tabs: [
       {
         id: 'mcp',
-        type: 'BUILT-IN APP TOOL',
-        title: '內建系統時間工具',
-        badge: 'Built-in App Tool',
-        desc: '在 AI 想要獲取設備時間時，調用內建 App Tool；它不屬於外部 MCP 工具，參數為空。',
-        snippet: `// Built-in App Tool Execution
+        type: 'BUILT-IN MCP SERVER',
+        title: '內建資料庫 MCP Server',
+        badge: 'Official Swift MCP SDK',
+        desc: 'ETOS 將資料庫 App Tool 包裝為內建 MCP Server；下面透過標準 tools/call 列出記憶資料庫表結構。',
+        snippet: `// builtin://app-tools/database
 {
-  "tool": "app_get_system_time",
-  "arguments": {}
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "app_list_sqlite_tables",
+    "arguments": {
+      "database": "memory",
+      "include_create_sql": true
+    }
+  }
 }`
       },
       {
@@ -1357,18 +1417,18 @@ function main(input) {
       },
       {
         id: 'rag',
-        type: 'SQLCIPHER RAG',
-        title: 'SQLite 全盤物理加密向量庫',
-        badge: 'GRDB + SQLCipher',
-        desc: '本地 Embedding 與長效記憶直接落地在加密 SQLite 數據庫中，支援 SillyTavern 世界書觸發。',
+        type: 'LOCAL RAG INDEX',
+        title: 'SQLite 本地向量索引',
+        badge: 'SQLite3',
+        desc: '本地 Embedding 索引保存在 memory_vectors.sqlite 的 memory_chunks 表中，並與長效記憶及 SillyTavern 世界書配合使用。',
         snippet: `-- memory_vectors.sqlite
-CREATE TABLE memory_chunks (
+CREATE TABLE IF NOT EXISTS memory_chunks (
   chunk_id TEXT PRIMARY KEY,
   parent_memory_id TEXT NOT NULL,
   text TEXT NOT NULL,
   embedding BLOB NOT NULL,
   metadata TEXT NOT NULL
-) STRICT;`
+);`
       }
     ]
   },

--- a/docs/landing/src/i18n.js
+++ b/docs/landing/src/i18n.js
@@ -55,22 +55,22 @@ const zh = {
     kvCacheInactiveLabel: 'KV Cache 未开启',
     models: [
       {
-        name: 'Qwen2.5-7B-Instruct.Q4_K_M.gguf',
-        size: '4.35 GB',
+        name: 'Phi-4-mini-Instruct.Q4_K_M.gguf',
+        size: '2.48 GB',
         thinking: '正在使用 Metal GPU 加速计算，分析对话上下文与 GGUF Jinja 对话模板...',
         response: '完全不需要网络或 API Key！模型权重与 Embedding 嵌入向量数据库完全运行在你的 iPhone 本机设备上。零联网权限，不消耗流量，隐私 100% 物理隔离。'
       },
       {
-        name: 'DeepSeek-R1-Distill-Llama-8B.Q4_K_M.gguf',
-        size: '4.92 GB',
-        thinking: '正在解析 <think> 推理链：1. 检索本地 SQLite 数据库；2. 匹配 KV Cache 缓存前缀；3. 生成结构化思考步骤...',
-        response: 'DeepSeek-R1 本地推理完成！思考耗时 1.2 秒，全流式 Metal GPU 加速输出与 KV Cache 前缀复用正常。'
+        name: 'Gemma-3-4B-Instruct.Q4_K_M.gguf',
+        size: '2.85 GB',
+        thinking: 'Checking local GGUF memory budget and Metal GPU offload layers...',
+        response: 'Gemma 3 4B 本地推理完成！全流式 Metal GPU 加速输出与 KV Cache 前缀复用正常，内存占用仅 2.6 GB。'
       },
       {
-        name: 'Gemma-2-9B-Instruct.Q4_K_M.gguf',
-        size: '5.42 GB',
-        thinking: 'Checking local GGUF memory budget and Metal GPU offload layers...',
-        response: 'Gemma 2 9B local execution complete. All memory and KV offload operating strictly within iOS sandbox limits.'
+        name: 'Qwen3-8B-Instruct.Q4_K_M.gguf',
+        size: '4.92 GB',
+        thinking: '正在解析 <think> 推理链：1. 检索本地 SQLite 数据库；2. 匹配 KV Cache 缓存前缀；3. 生成结构化思考步骤...',
+        response: 'Qwen3 8B 本地推理完成！思考耗时 1.1 秒，全流式 Metal GPU 加速输出与 KV Cache 前缀复用正常，速率达 42+ t/s。'
       }
     ]
   },
@@ -312,22 +312,22 @@ const en = {
     kvCacheInactiveLabel: 'KV Cache Disabled',
     models: [
       {
-        name: 'Qwen2.5-7B-Instruct.Q4_K_M.gguf',
-        size: '4.35 GB',
+        name: 'Phi-4-mini-Instruct.Q4_K_M.gguf',
+        size: '2.48 GB',
         thinking: 'Accelerating via Metal GPU, analyzing chat context and GGUF Jinja chat template...',
         response: 'No network or API key required! Model weights and SQLite vector database run 100% locally on your iPhone with zero telemetry.'
       },
       {
-        name: 'DeepSeek-R1-Distill-Llama-8B.Q4_K_M.gguf',
-        size: '4.92 GB',
-        thinking: 'Parsing <think> reasoning chain: 1. Search local SQLite; 2. Match KV Cache prefix; 3. Generate structured thinking steps...',
-        response: 'DeepSeek-R1 local inference complete! Reasoning duration 1.2s with full Metal GPU acceleration and KV Cache prefix reuse.'
+        name: 'Gemma-3-4B-Instruct.Q4_K_M.gguf',
+        size: '2.85 GB',
+        thinking: 'Checking local GGUF memory budget and Metal GPU offload layers...',
+        response: 'Gemma 3 4B local execution complete. All memory and KV offload operating strictly within iOS sandbox limits with 2.6 GB RAM.'
       },
       {
-        name: 'Gemma-2-9B-Instruct.Q4_K_M.gguf',
-        size: '5.42 GB',
-        thinking: 'Checking local GGUF memory budget and Metal GPU offload layers...',
-        response: 'Gemma 2 9B local execution complete. All memory and KV offload operating strictly within iOS sandbox limits.'
+        name: 'Qwen3-8B-Instruct.Q4_K_M.gguf',
+        size: '4.92 GB',
+        thinking: 'Parsing <think> reasoning chain: 1. Search local SQLite; 2. Match KV Cache prefix; 3. Generate structured thinking steps...',
+        response: 'Qwen3 8B local inference complete! Reasoning duration 1.1s with full Metal GPU acceleration and 42+ t/s throughput.'
       }
     ]
   },
@@ -569,22 +569,22 @@ const ja = {
     kvCacheInactiveLabel: 'KV Cache 未有効化',
     models: [
       {
-        name: 'Qwen2.5-7B-Instruct.Q4_K_M.gguf',
-        size: '4.35 GB',
+        name: 'Phi-4-mini-Instruct.Q4_K_M.gguf',
+        size: '2.48 GB',
         thinking: 'Metal GPU 加速で計算中、GGUF Jinja テンプレートを解析中...',
         response: 'ネット接続や API キーは一切不要です！モデルウェイトと SQLite ベクトル DB は端末内で 100% ローカル動作します。'
       },
       {
-        name: 'DeepSeek-R1-Distill-Llama-8B.Q4_K_M.gguf',
-        size: '4.92 GB',
-        thinking: '<think> 推論チェーンを解析中: 1. SQLite 検索; 2. KV Cache マッチング; 3. 思考ステップ生成...',
-        response: 'DeepSeek-R1 ローカル推論完了！思考時間 1.2 秒、Metal GPU 加速と KV Cache 再利用が正常に動作しています。'
+        name: 'Gemma-3-4B-Instruct.Q4_K_M.gguf',
+        size: '2.85 GB',
+        thinking: 'Checking local GGUF memory budget and Metal GPU offload layers...',
+        response: 'Gemma 3 4B ローカル推論完了！Metal GPU 加速と KV Cache 再利用が正常に動作しています。'
       },
       {
-        name: 'Gemma-2-9B-Instruct.Q4_K_M.gguf',
-        size: '5.42 GB',
-        thinking: 'Checking local GGUF memory budget and Metal GPU offload layers...',
-        response: 'Gemma 2 9B local execution complete. All memory and KV offload operating strictly within iOS sandbox limits.'
+        name: 'Qwen3-8B-Instruct.Q4_K_M.gguf',
+        size: '4.92 GB',
+        thinking: '<think> 推論チェーンを解析中: 1. SQLite 検索; 2. KV Cache マッチング; 3. 思考ステップ生成...',
+        response: 'Qwen3 8B ローカル推論完了！思考時間 1.1 秒、42+ t/s で動作しています。'
       }
     ]
   },
@@ -817,22 +817,22 @@ const ru = {
     kvCacheInactiveLabel: 'KV Cache отключен',
     models: [
       {
-        name: 'Qwen2.5-7B-Instruct.Q4_K_M.gguf',
-        size: '4.35 GB',
+        name: 'Phi-4-mini-Instruct.Q4_K_M.gguf',
+        size: '2.48 GB',
         thinking: 'Ускорение Metal GPU, анализ контекста чата и шаблона GGUF Jinja...',
         response: 'Интернет и API ключ не требуются! Веса модели и векторная база SQLite работают 100% локально на вашем iPhone.'
       },
       {
-        name: 'DeepSeek-R1-Distill-Llama-8B.Q4_K_M.gguf',
-        size: '4.92 GB',
-        thinking: 'Разбор цепочки <think>: 1. Поиск SQLite; 2. Совпадение KV Cache; 3. Генерация шагов...',
-        response: 'Локальный инференс DeepSeek-R1 завершен! Время размышления 1.2с с ускорением Metal GPU.'
+        name: 'Gemma-3-4B-Instruct.Q4_K_M.gguf',
+        size: '2.85 GB',
+        thinking: 'Checking local GGUF memory budget and Metal GPU offload layers...',
+        response: 'Локальный инференс Gemma 3 4B завершен! Ускорение Metal GPU и использование памяти 2.6 ГБ.'
       },
       {
-        name: 'Gemma-2-9B-Instruct.Q4_K_M.gguf',
-        size: '5.42 GB',
-        thinking: 'Checking local GGUF memory budget and Metal GPU offload layers...',
-        response: 'Gemma 2 9B local execution complete. All memory and KV offload operating strictly within iOS sandbox limits.'
+        name: 'Qwen3-8B-Instruct.Q4_K_M.gguf',
+        size: '4.92 GB',
+        thinking: 'Разбор цепочки <think>: 1. Поиск SQLite; 2. Совпадение KV Cache; 3. Генерация шагов...',
+        response: 'Локальный инференс Qwen3 8B завершен! Время размышления 1.1с со скоростью 42+ т/с.'
       }
     ]
   },
@@ -1065,22 +1065,22 @@ const zhHant = {
     kvCacheInactiveLabel: 'KV Cache 未開啟',
     models: [
       {
-        name: 'Qwen2.5-7B-Instruct.Q4_K_M.gguf',
-        size: '4.35 GB',
+        name: 'Phi-4-mini-Instruct.Q4_K_M.gguf',
+        size: '2.48 GB',
         thinking: '正在使用 Metal GPU 加速計算，分析對話上下文與 GGUF Jinja 對話模板...',
         response: '完全不需要網路或 API Key！模型權重與 Embedding 嵌入向量數據庫完全運行在你的 iPhone 本機設備上。零聯網權限，不消耗流量，隱私 100% 物理隔離。'
       },
       {
-        name: 'DeepSeek-R1-Distill-Llama-8B.Q4_K_M.gguf',
-        size: '4.92 GB',
-        thinking: '正在解析 <think> 推理鏈：1. 檢索本地 SQLite 數據庫；2. 匹配 KV Cache 快取前綴；3. 生成結構化思考步驟...',
-        response: 'DeepSeek-R1 本地推理完成！思考耗時 1.2 秒，全流式 Metal GPU 加速輸出與 KV Cache 快取前綴複用正常。'
+        name: 'Gemma-3-4B-Instruct.Q4_K_M.gguf',
+        size: '2.85 GB',
+        thinking: 'Checking local GGUF memory budget and Metal GPU offload layers...',
+        response: 'Gemma 3 4B 本地推理完成！全流式 Metal GPU 加速輸出與 KV Cache 快取前綴複用正常，記憶體佔用僅 2.6 GB。'
       },
       {
-        name: 'Gemma-2-9B-Instruct.Q4_K_M.gguf',
-        size: '5.42 GB',
-        thinking: 'Checking local GGUF memory budget and Metal GPU offload layers...',
-        response: 'Gemma 2 9B local execution complete. All memory and KV offload operating strictly within iOS sandbox limits.'
+        name: 'Qwen3-8B-Instruct.Q4_K_M.gguf',
+        size: '4.92 GB',
+        thinking: '正在解析 <think> 推理鏈：1. 檢索本地 SQLite 數據庫；2. 匹配 KV Cache 快取前綴；3. 生成結構化思考步驟...',
+        response: 'Qwen3 8B 本地推理完成！思考耗時 1.1 秒，全流式 Metal GPU 加速輸出與 KV Cache 快取前綴複用正常，速率達 42+ t/s。'
       }
     ]
   },

--- a/docs/landing/src/i18n.js
+++ b/docs/landing/src/i18n.js
@@ -57,20 +57,59 @@ const zh = {
       {
         name: 'Phi-4-mini-Instruct.Q4_K_M.gguf',
         size: '2.48 GB',
+        hud: {
+          cpuMetal: '13%',
+          cpuOnly: '63%',
+          gpuMetal: '78%',
+          ramMetal: '2.7 GB (Metal)',
+          ramMetalKV: '3.0 GB (Metal + KV)',
+          ramCpu: '3.1 GB (RAM)',
+          ramCpuKV: '3.4 GB (RAM + KV)',
+          speedFlash: 49.6,
+          speedFlashKV: 57.8,
+          speedBase: 29.8,
+          speedKV: 34.2
+        },
         thinking: '正在使用 Metal GPU 加速计算，分析对话上下文与 GGUF Jinja 对话模板...',
         response: '完全不需要网络或 API Key！模型权重与 Embedding 嵌入向量数据库完全运行在你的 iPhone 本机设备上。零联网权限，不消耗流量，隐私 100% 物理隔离。'
       },
       {
         name: 'Gemma-3-4B-Instruct.Q4_K_M.gguf',
         size: '2.85 GB',
+        hud: {
+          cpuMetal: '17%',
+          cpuOnly: '69%',
+          gpuMetal: '84%',
+          ramMetal: '3.1 GB (Metal)',
+          ramMetalKV: '3.5 GB (Metal + KV)',
+          ramCpu: '3.7 GB (RAM)',
+          ramCpuKV: '4.1 GB (RAM + KV)',
+          speedFlash: 38.0,
+          speedFlashKV: 44.3,
+          speedBase: 23.2,
+          speedKV: 26.8
+        },
         thinking: 'Checking local GGUF memory budget and Metal GPU offload layers...',
-        response: 'Gemma 3 4B 本地推理完成！全流式 Metal GPU 加速输出与 KV Cache 前缀复用正常，内存占用仅 2.6 GB。'
+        response: 'Gemma 3 4B 本地推理完成！全流式 Metal GPU 加速输出与 KV Cache 前缀复用正常，内存占用按上下文缓存同步增加。'
       },
       {
         name: 'Qwen3-8B-Instruct.Q4_K_M.gguf',
         size: '4.92 GB',
+        hud: {
+          cpuMetal: '24%',
+          cpuOnly: '82%',
+          gpuMetal: '91%',
+          ramMetal: '5.2 GB (Metal)',
+          ramMetalKV: '5.8 GB (Metal + KV)',
+          ramCpu: '6.1 GB (RAM)',
+          ramCpuKV: '6.8 GB (RAM + KV)',
+          speedFlash: 26.4,
+          speedFlashKV: 30.5,
+          speedBase: 15.7,
+          speedKV: 18.2
+        },
         thinking: '正在解析 <think> 推理链：1. 检索本地 SQLite 数据库；2. 匹配 KV Cache 缓存前缀；3. 生成结构化思考步骤...',
-        response: 'Qwen3 8B 本地推理完成！思考耗时 1.1 秒，全流式 Metal GPU 加速输出与 KV Cache 前缀复用正常，速率达 42+ t/s。'
+        response: 'Qwen3 8B 本地推理完成！全流式 Metal GPU 加速输出与 KV Cache 前缀复用正常，吞吐与内存占用按 8B 模型规模显示。'
       }
     ]
   },
@@ -81,16 +120,14 @@ const zh = {
     tabs: [
       {
         id: 'mcp',
-        type: 'MCP SERVER',
-        title: 'Built-in App Tool MCP',
-        badge: 'Official Swift MCP SDK',
-        desc: '在 AI 想要获取设备时间或查询沙盒时，统一通过内建 MCP 服务器调度，且支持原生问答 Sheet 审批策略。',
-        snippet: `// Built-in App Tool MCP Execution
+        type: 'BUILT-IN APP TOOL',
+        title: '内置系统时间工具',
+        badge: 'Built-in App Tool',
+        desc: '在 AI 想要获取设备时间时，调用内置 App Tool；它不属于外部 MCP 工具，参数为空。',
+        snippet: `// Built-in App Tool Execution
 {
-  "server": "etos_builtin_app_tool",
   "tool": "app_get_system_time",
-  "arguments": { "timezone": "Asia/Shanghai" },
-  "approval": "ASK_USER_CONFIRMATION"
+  "arguments": {}
 }`
       },
       {
@@ -99,11 +136,17 @@ const zh = {
         title: 'GitHub 技能包一键导入',
         badge: 'Agentic Skill Pack',
         desc: '直接粘贴 GitHub 仓库链接或 RAW 文件地址，即刻注入代码审查、海报生成或工作流指令集。',
-        snippet: `# SKILL: CodeReviewer Pro
+        snippet: `---
+name: code-reviewer-pro
 description: "Inspect Swift & Rust diffs for memory leaks"
-tools: [app_read_sandbox_file, app_query_sqlite]
-instructions: |
-  Check for strong reference cycles in closure capture lists.`
+allowed-tools:
+  - app_read_sandbox_file
+  - app_query_sqlite
+---
+
+# CodeReviewer Pro
+
+检查 Swift 闭包捕获列表、Rust unsafe 边界与数据库迁移风险。`
       },
       {
         id: 'jsc',
@@ -128,11 +171,13 @@ function main(input) {
         title: 'SQLite 全盘物理加密向量库',
         badge: 'GRDB + SQLCipher',
         desc: '本地 Embedding 与长效记忆直接落地在加密 SQLite 数据库中，支持 SillyTavern 世界书触发。',
-        snippet: `CREATE TABLE memory_vectors (
-  id TEXT PRIMARY KEY,
-  vector BLOB NOT NULL,
-  content TEXT NOT NULL,
-  created_at INTEGER NOT NULL
+        snippet: `-- memory_vectors.sqlite
+CREATE TABLE memory_chunks (
+  chunk_id TEXT PRIMARY KEY,
+  parent_memory_id TEXT NOT NULL,
+  text TEXT NOT NULL,
+  embedding BLOB NOT NULL,
+  metadata TEXT NOT NULL
 ) STRICT;`
       }
     ]
@@ -314,20 +359,59 @@ const en = {
       {
         name: 'Phi-4-mini-Instruct.Q4_K_M.gguf',
         size: '2.48 GB',
+        hud: {
+          cpuMetal: '13%',
+          cpuOnly: '63%',
+          gpuMetal: '78%',
+          ramMetal: '2.7 GB (Metal)',
+          ramMetalKV: '3.0 GB (Metal + KV)',
+          ramCpu: '3.1 GB (RAM)',
+          ramCpuKV: '3.4 GB (RAM + KV)',
+          speedFlash: 49.6,
+          speedFlashKV: 57.8,
+          speedBase: 29.8,
+          speedKV: 34.2
+        },
         thinking: 'Accelerating via Metal GPU, analyzing chat context and GGUF Jinja chat template...',
         response: 'No network or API key required! Model weights and SQLite vector database run 100% locally on your iPhone with zero telemetry.'
       },
       {
         name: 'Gemma-3-4B-Instruct.Q4_K_M.gguf',
         size: '2.85 GB',
+        hud: {
+          cpuMetal: '17%',
+          cpuOnly: '69%',
+          gpuMetal: '84%',
+          ramMetal: '3.1 GB (Metal)',
+          ramMetalKV: '3.5 GB (Metal + KV)',
+          ramCpu: '3.7 GB (RAM)',
+          ramCpuKV: '4.1 GB (RAM + KV)',
+          speedFlash: 38.0,
+          speedFlashKV: 44.3,
+          speedBase: 23.2,
+          speedKV: 26.8
+        },
         thinking: 'Checking local GGUF memory budget and Metal GPU offload layers...',
-        response: 'Gemma 3 4B local execution complete. All memory and KV offload operating strictly within iOS sandbox limits with 2.6 GB RAM.'
+        response: 'Gemma 3 4B local execution complete. Metal streaming and KV prefix reuse are active, with memory increasing to reflect the cached context.'
       },
       {
         name: 'Qwen3-8B-Instruct.Q4_K_M.gguf',
         size: '4.92 GB',
+        hud: {
+          cpuMetal: '24%',
+          cpuOnly: '82%',
+          gpuMetal: '91%',
+          ramMetal: '5.2 GB (Metal)',
+          ramMetalKV: '5.8 GB (Metal + KV)',
+          ramCpu: '6.1 GB (RAM)',
+          ramCpuKV: '6.8 GB (RAM + KV)',
+          speedFlash: 26.4,
+          speedFlashKV: 30.5,
+          speedBase: 15.7,
+          speedKV: 18.2
+        },
         thinking: 'Parsing <think> reasoning chain: 1. Search local SQLite; 2. Match KV Cache prefix; 3. Generate structured thinking steps...',
-        response: 'Qwen3 8B local inference complete! Reasoning duration 1.1s with full Metal GPU acceleration and 42+ t/s throughput.'
+        response: 'Qwen3 8B local inference complete. Metal acceleration and KV reuse are active, with throughput and memory shown at the larger 8B scale.'
       }
     ]
   },
@@ -338,16 +422,14 @@ const en = {
     tabs: [
       {
         id: 'mcp',
-        type: 'MCP SERVER',
-        title: 'Built-in App Tool MCP',
-        badge: 'Official Swift MCP SDK',
-        desc: 'When AI requests system time or sandbox access, requests route through the built-in MCP server with native approval Sheet controls.',
-        snippet: `// Built-in App Tool MCP Execution
+        type: 'BUILT-IN APP TOOL',
+        title: 'Built-in System Time Tool',
+        badge: 'Built-in App Tool',
+        desc: 'When AI requests device time, it calls a built-in App Tool. This is not an external MCP tool and takes no arguments.',
+        snippet: `// Built-in App Tool Execution
 {
-  "server": "etos_builtin_app_tool",
   "tool": "app_get_system_time",
-  "arguments": { "timezone": "America/New_York" },
-  "approval": "ASK_USER_CONFIRMATION"
+  "arguments": {}
 }`
       },
       {
@@ -356,11 +438,17 @@ const en = {
         title: 'GitHub Skill Import',
         badge: 'Agentic Skill Pack',
         desc: 'Paste GitHub repo links or RAW file URLs to inject code inspection or prompt workflow skill packs.',
-        snippet: `# SKILL: CodeReviewer Pro
+        snippet: `---
+name: code-reviewer-pro
 description: "Inspect Swift & Rust diffs for memory leaks"
-tools: [app_read_sandbox_file, app_query_sqlite]
-instructions: |
-  Check for strong reference cycles in closure capture lists.`
+allowed-tools:
+  - app_read_sandbox_file
+  - app_query_sqlite
+---
+
+# CodeReviewer Pro
+
+Check Swift closure captures, Rust unsafe boundaries, and database migration risks.`
       },
       {
         id: 'jsc',
@@ -385,11 +473,13 @@ function main(input) {
         title: 'SQLite Encrypted Vector Store',
         badge: 'GRDB + SQLCipher',
         desc: 'Local embeddings and long-term memory stored inside encrypted SQLite database with SillyTavern Worldbook support.',
-        snippet: `CREATE TABLE memory_vectors (
-  id TEXT PRIMARY KEY,
-  vector BLOB NOT NULL,
-  content TEXT NOT NULL,
-  created_at INTEGER NOT NULL
+        snippet: `-- memory_vectors.sqlite
+CREATE TABLE memory_chunks (
+  chunk_id TEXT PRIMARY KEY,
+  parent_memory_id TEXT NOT NULL,
+  text TEXT NOT NULL,
+  embedding BLOB NOT NULL,
+  metadata TEXT NOT NULL
 ) STRICT;`
       }
     ]
@@ -571,20 +661,59 @@ const ja = {
       {
         name: 'Phi-4-mini-Instruct.Q4_K_M.gguf',
         size: '2.48 GB',
+        hud: {
+          cpuMetal: '13%',
+          cpuOnly: '63%',
+          gpuMetal: '78%',
+          ramMetal: '2.7 GB (Metal)',
+          ramMetalKV: '3.0 GB (Metal + KV)',
+          ramCpu: '3.1 GB (RAM)',
+          ramCpuKV: '3.4 GB (RAM + KV)',
+          speedFlash: 49.6,
+          speedFlashKV: 57.8,
+          speedBase: 29.8,
+          speedKV: 34.2
+        },
         thinking: 'Metal GPU 加速で計算中、GGUF Jinja テンプレートを解析中...',
         response: 'ネット接続や API キーは一切不要です！モデルウェイトと SQLite ベクトル DB は端末内で 100% ローカル動作します。'
       },
       {
         name: 'Gemma-3-4B-Instruct.Q4_K_M.gguf',
         size: '2.85 GB',
+        hud: {
+          cpuMetal: '17%',
+          cpuOnly: '69%',
+          gpuMetal: '84%',
+          ramMetal: '3.1 GB (Metal)',
+          ramMetalKV: '3.5 GB (Metal + KV)',
+          ramCpu: '3.7 GB (RAM)',
+          ramCpuKV: '4.1 GB (RAM + KV)',
+          speedFlash: 38.0,
+          speedFlashKV: 44.3,
+          speedBase: 23.2,
+          speedKV: 26.8
+        },
         thinking: 'Checking local GGUF memory budget and Metal GPU offload layers...',
-        response: 'Gemma 3 4B ローカル推論完了！Metal GPU 加速と KV Cache 再利用が正常に動作しています。'
+        response: 'Gemma 3 4B ローカル推論完了！Metal GPU 加速と KV Cache 再利用が正常に動作し、キャッシュ分のメモリも反映されています。'
       },
       {
         name: 'Qwen3-8B-Instruct.Q4_K_M.gguf',
         size: '4.92 GB',
+        hud: {
+          cpuMetal: '24%',
+          cpuOnly: '82%',
+          gpuMetal: '91%',
+          ramMetal: '5.2 GB (Metal)',
+          ramMetalKV: '5.8 GB (Metal + KV)',
+          ramCpu: '6.1 GB (RAM)',
+          ramCpuKV: '6.8 GB (RAM + KV)',
+          speedFlash: 26.4,
+          speedFlashKV: 30.5,
+          speedBase: 15.7,
+          speedKV: 18.2
+        },
         thinking: '<think> 推論チェーンを解析中: 1. SQLite 検索; 2. KV Cache マッチング; 3. 思考ステップ生成...',
-        response: 'Qwen3 8B ローカル推論完了！思考時間 1.1 秒、42+ t/s で動作しています。'
+        response: 'Qwen3 8B ローカル推論完了。8B モデル規模に合わせたスループットとメモリ使用量を表示しています。'
       }
     ]
   },
@@ -595,16 +724,14 @@ const ja = {
     tabs: [
       {
         id: 'mcp',
-        type: 'MCP SERVER',
-        title: 'Built-in App Tool MCP',
-        badge: 'Official Swift MCP SDK',
-        desc: 'システム時間やサンドボックスアクセスの要求は、組み込み MCP サーバーとネイティブ承認 Sheet 経由で安全に処理されます。',
-        snippet: `// Built-in App Tool MCP Execution
+        type: 'BUILT-IN APP TOOL',
+        title: '内蔵システム時刻ツール',
+        badge: 'Built-in App Tool',
+        desc: 'AI がデバイス時刻を必要とするときは内蔵 App Tool を呼び出します。外部 MCP ツールではなく、引数も不要です。',
+        snippet: `// Built-in App Tool Execution
 {
-  "server": "etos_builtin_app_tool",
   "tool": "app_get_system_time",
-  "arguments": { "timezone": "Asia/Tokyo" },
-  "approval": "ASK_USER_CONFIRMATION"
+  "arguments": {}
 }`
       },
       {
@@ -613,11 +740,17 @@ const ja = {
         title: 'GitHub スキルインポート',
         badge: 'Agentic Skill Pack',
         desc: 'GitHub リポジトリリンクや RAW URL を貼り付けるだけで、コードレビューやワークフロースキルを注入。',
-        snippet: `# SKILL: CodeReviewer Pro
+        snippet: `---
+name: code-reviewer-pro
 description: "Inspect Swift & Rust diffs for memory leaks"
-tools: [app_read_sandbox_file, app_query_sqlite]
-instructions: |
-  Check for strong reference cycles in closure capture lists.`
+allowed-tools:
+  - app_read_sandbox_file
+  - app_query_sqlite
+---
+
+# CodeReviewer Pro
+
+Swift のクロージャキャプチャ、Rust unsafe 境界、データベース移行リスクを確認します。`
       },
       {
         id: 'jsc',
@@ -642,11 +775,13 @@ function main(input) {
         title: 'SQLite 暗号化ベクトルストア',
         badge: 'GRDB + SQLCipher',
         desc: '暗号化 SQLite データベース内に長期記憶を保存。SillyTavern ワールドブック対応。',
-        snippet: `CREATE TABLE memory_vectors (
-  id TEXT PRIMARY KEY,
-  vector BLOB NOT NULL,
-  content TEXT NOT NULL,
-  created_at INTEGER NOT NULL
+        snippet: `-- memory_vectors.sqlite
+CREATE TABLE memory_chunks (
+  chunk_id TEXT PRIMARY KEY,
+  parent_memory_id TEXT NOT NULL,
+  text TEXT NOT NULL,
+  embedding BLOB NOT NULL,
+  metadata TEXT NOT NULL
 ) STRICT;`
       }
     ]
@@ -819,20 +954,59 @@ const ru = {
       {
         name: 'Phi-4-mini-Instruct.Q4_K_M.gguf',
         size: '2.48 GB',
+        hud: {
+          cpuMetal: '13%',
+          cpuOnly: '63%',
+          gpuMetal: '78%',
+          ramMetal: '2.7 GB (Metal)',
+          ramMetalKV: '3.0 GB (Metal + KV)',
+          ramCpu: '3.1 GB (RAM)',
+          ramCpuKV: '3.4 GB (RAM + KV)',
+          speedFlash: 49.6,
+          speedFlashKV: 57.8,
+          speedBase: 29.8,
+          speedKV: 34.2
+        },
         thinking: 'Ускорение Metal GPU, анализ контекста чата и шаблона GGUF Jinja...',
         response: 'Интернет и API ключ не требуются! Веса модели и векторная база SQLite работают 100% локально на вашем iPhone.'
       },
       {
         name: 'Gemma-3-4B-Instruct.Q4_K_M.gguf',
         size: '2.85 GB',
+        hud: {
+          cpuMetal: '17%',
+          cpuOnly: '69%',
+          gpuMetal: '84%',
+          ramMetal: '3.1 GB (Metal)',
+          ramMetalKV: '3.5 GB (Metal + KV)',
+          ramCpu: '3.7 GB (RAM)',
+          ramCpuKV: '4.1 GB (RAM + KV)',
+          speedFlash: 38.0,
+          speedFlashKV: 44.3,
+          speedBase: 23.2,
+          speedKV: 26.8
+        },
         thinking: 'Checking local GGUF memory budget and Metal GPU offload layers...',
-        response: 'Локальный инференс Gemma 3 4B завершен! Ускорение Metal GPU и использование памяти 2.6 ГБ.'
+        response: 'Локальный инференс Gemma 3 4B завершен! Metal GPU и KV Cache активны, а память включает дополнительный контекстный кэш.'
       },
       {
         name: 'Qwen3-8B-Instruct.Q4_K_M.gguf',
         size: '4.92 GB',
+        hud: {
+          cpuMetal: '24%',
+          cpuOnly: '82%',
+          gpuMetal: '91%',
+          ramMetal: '5.2 GB (Metal)',
+          ramMetalKV: '5.8 GB (Metal + KV)',
+          ramCpu: '6.1 GB (RAM)',
+          ramCpuKV: '6.8 GB (RAM + KV)',
+          speedFlash: 26.4,
+          speedFlashKV: 30.5,
+          speedBase: 15.7,
+          speedKV: 18.2
+        },
         thinking: 'Разбор цепочки <think>: 1. Поиск SQLite; 2. Совпадение KV Cache; 3. Генерация шагов...',
-        response: 'Локальный инференс Qwen3 8B завершен! Время размышления 1.1с со скоростью 42+ т/с.'
+        response: 'Локальный инференс Qwen3 8B завершен. HUD показывает пропускную способность и память с учетом масштаба 8B модели.'
       }
     ]
   },
@@ -843,16 +1017,14 @@ const ru = {
     tabs: [
       {
         id: 'mcp',
-        type: 'MCP SERVER',
-        title: 'Built-in App Tool MCP',
-        badge: 'Official Swift MCP SDK',
-        desc: 'Запросы к системному времени или песочнице направляются через встроенный MCP сервер с нативным подтверждением.',
-        snippet: `// Built-in App Tool MCP Execution
+        type: 'BUILT-IN APP TOOL',
+        title: 'Встроенный инструмент системного времени',
+        badge: 'Built-in App Tool',
+        desc: 'Когда AI требуется время устройства, он вызывает встроенный App Tool. Это не внешний MCP инструмент, и аргументы не нужны.',
+        snippet: `// Built-in App Tool Execution
 {
-  "server": "etos_builtin_app_tool",
   "tool": "app_get_system_time",
-  "arguments": { "timezone": "Europe/Moscow" },
-  "approval": "ASK_USER_CONFIRMATION"
+  "arguments": {}
 }`
       },
       {
@@ -861,11 +1033,17 @@ const ru = {
         title: 'Импорт навыков GitHub',
         badge: 'Agentic Skill Pack',
         desc: 'Вставьте ссылку на GitHub или RAW URL для внедрения пакетов навыков ревью кода и рабочих процессов.',
-        snippet: `# SKILL: CodeReviewer Pro
+        snippet: `---
+name: code-reviewer-pro
 description: "Inspect Swift & Rust diffs for memory leaks"
-tools: [app_read_sandbox_file, app_query_sqlite]
-instructions: |
-  Check for strong reference cycles in closure capture lists.`
+allowed-tools:
+  - app_read_sandbox_file
+  - app_query_sqlite
+---
+
+# CodeReviewer Pro
+
+Check Swift closure captures, Rust unsafe boundaries, and database migration risks.`
       },
       {
         id: 'jsc',
@@ -890,11 +1068,13 @@ function main(input) {
         title: 'Зашифрованная база SQLite RAG',
         badge: 'GRDB + SQLCipher',
         desc: 'Долгосрочная память сохраняется в зашифрованной базе SQLite с поддержкой SillyTavern Worldbook.',
-        snippet: `CREATE TABLE memory_vectors (
-  id TEXT PRIMARY KEY,
-  vector BLOB NOT NULL,
-  content TEXT NOT NULL,
-  created_at INTEGER NOT NULL
+        snippet: `-- memory_vectors.sqlite
+CREATE TABLE memory_chunks (
+  chunk_id TEXT PRIMARY KEY,
+  parent_memory_id TEXT NOT NULL,
+  text TEXT NOT NULL,
+  embedding BLOB NOT NULL,
+  metadata TEXT NOT NULL
 ) STRICT;`
       }
     ]
@@ -1067,20 +1247,59 @@ const zhHant = {
       {
         name: 'Phi-4-mini-Instruct.Q4_K_M.gguf',
         size: '2.48 GB',
+        hud: {
+          cpuMetal: '13%',
+          cpuOnly: '63%',
+          gpuMetal: '78%',
+          ramMetal: '2.7 GB (Metal)',
+          ramMetalKV: '3.0 GB (Metal + KV)',
+          ramCpu: '3.1 GB (RAM)',
+          ramCpuKV: '3.4 GB (RAM + KV)',
+          speedFlash: 49.6,
+          speedFlashKV: 57.8,
+          speedBase: 29.8,
+          speedKV: 34.2
+        },
         thinking: '正在使用 Metal GPU 加速計算，分析對話上下文與 GGUF Jinja 對話模板...',
         response: '完全不需要網路或 API Key！模型權重與 Embedding 嵌入向量數據庫完全運行在你的 iPhone 本機設備上。零聯網權限，不消耗流量，隱私 100% 物理隔離。'
       },
       {
         name: 'Gemma-3-4B-Instruct.Q4_K_M.gguf',
         size: '2.85 GB',
+        hud: {
+          cpuMetal: '17%',
+          cpuOnly: '69%',
+          gpuMetal: '84%',
+          ramMetal: '3.1 GB (Metal)',
+          ramMetalKV: '3.5 GB (Metal + KV)',
+          ramCpu: '3.7 GB (RAM)',
+          ramCpuKV: '4.1 GB (RAM + KV)',
+          speedFlash: 38.0,
+          speedFlashKV: 44.3,
+          speedBase: 23.2,
+          speedKV: 26.8
+        },
         thinking: 'Checking local GGUF memory budget and Metal GPU offload layers...',
-        response: 'Gemma 3 4B 本地推理完成！全流式 Metal GPU 加速輸出與 KV Cache 快取前綴複用正常，記憶體佔用僅 2.6 GB。'
+        response: 'Gemma 3 4B 本地推理完成！全流式 Metal GPU 加速輸出與 KV Cache 快取前綴複用正常，記憶體佔用會隨上下文快取同步增加。'
       },
       {
         name: 'Qwen3-8B-Instruct.Q4_K_M.gguf',
         size: '4.92 GB',
+        hud: {
+          cpuMetal: '24%',
+          cpuOnly: '82%',
+          gpuMetal: '91%',
+          ramMetal: '5.2 GB (Metal)',
+          ramMetalKV: '5.8 GB (Metal + KV)',
+          ramCpu: '6.1 GB (RAM)',
+          ramCpuKV: '6.8 GB (RAM + KV)',
+          speedFlash: 26.4,
+          speedFlashKV: 30.5,
+          speedBase: 15.7,
+          speedKV: 18.2
+        },
         thinking: '正在解析 <think> 推理鏈：1. 檢索本地 SQLite 數據庫；2. 匹配 KV Cache 快取前綴；3. 生成結構化思考步驟...',
-        response: 'Qwen3 8B 本地推理完成！思考耗時 1.1 秒，全流式 Metal GPU 加速輸出與 KV Cache 快取前綴複用正常，速率達 42+ t/s。'
+        response: 'Qwen3 8B 本地推理完成！全流式 Metal GPU 加速輸出與 KV Cache 快取前綴複用正常，吞吐與記憶體佔用按 8B 模型規模顯示。'
       }
     ]
   },
@@ -1091,16 +1310,14 @@ const zhHant = {
     tabs: [
       {
         id: 'mcp',
-        type: 'MCP SERVER',
-        title: 'Built-in App Tool MCP',
-        badge: 'Official Swift MCP SDK',
-        desc: '在 AI 想要獲取設備時間或查詢沙盒時，統一通過內建 MCP 伺服器調度，且支援原生問答 Sheet 審批策略。',
-        snippet: `// Built-in App Tool MCP Execution
+        type: 'BUILT-IN APP TOOL',
+        title: '內建系統時間工具',
+        badge: 'Built-in App Tool',
+        desc: '在 AI 想要獲取設備時間時，調用內建 App Tool；它不屬於外部 MCP 工具，參數為空。',
+        snippet: `// Built-in App Tool Execution
 {
-  "server": "etos_builtin_app_tool",
   "tool": "app_get_system_time",
-  "arguments": { "timezone": "Asia/Taipei" },
-  "approval": "ASK_USER_CONFIRMATION"
+  "arguments": {}
 }`
       },
       {
@@ -1109,11 +1326,17 @@ const zhHant = {
         title: 'GitHub 技能包一鍵導入',
         badge: 'Agentic Skill Pack',
         desc: '直接粘貼 GitHub 倉庫鏈接或 RAW 檔案地址，即刻注入代碼審查、海報生成或工作流指令集。',
-        snippet: `# SKILL: CodeReviewer Pro
+        snippet: `---
+name: code-reviewer-pro
 description: "Inspect Swift & Rust diffs for memory leaks"
-tools: [app_read_sandbox_file, app_query_sqlite]
-instructions: |
-  Check for strong reference cycles in closure capture lists.`
+allowed-tools:
+  - app_read_sandbox_file
+  - app_query_sqlite
+---
+
+# CodeReviewer Pro
+
+檢查 Swift 閉包捕獲列表、Rust unsafe 邊界與資料庫遷移風險。`
       },
       {
         id: 'jsc',
@@ -1138,11 +1361,13 @@ function main(input) {
         title: 'SQLite 全盤物理加密向量庫',
         badge: 'GRDB + SQLCipher',
         desc: '本地 Embedding 與長效記憶直接落地在加密 SQLite 數據庫中，支援 SillyTavern 世界書觸發。',
-        snippet: `CREATE TABLE memory_vectors (
-  id TEXT PRIMARY KEY,
-  vector BLOB NOT NULL,
-  content TEXT NOT NULL,
-  created_at INTEGER NOT NULL
+        snippet: `-- memory_vectors.sqlite
+CREATE TABLE memory_chunks (
+  chunk_id TEXT PRIMARY KEY,
+  parent_memory_id TEXT NOT NULL,
+  text TEXT NOT NULL,
+  embedding BLOB NOT NULL,
+  metadata TEXT NOT NULL
 ) STRICT;`
       }
     ]

--- a/docs/landing/src/style.css
+++ b/docs/landing/src/style.css
@@ -1791,6 +1791,13 @@ img {
   margin-top: 4px;
 }
 
+.hud-estimate-note {
+  margin: -8px 0 0;
+  color: #64748b;
+  font-size: 11px;
+  line-height: 1.45;
+}
+
 .hud-stat {
   background: #141417;
   border: 1px solid #26262c;
@@ -1859,7 +1866,14 @@ img {
   display: flex;
   align-items: center;
   gap: 8px;
+  min-width: 0;
   color: #e2e8f0;
+}
+
+.hud-model-tag {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .hud-dot {
@@ -1874,6 +1888,7 @@ img {
   display: flex;
   align-items: center;
   gap: 8px;
+  flex-shrink: 0;
 }
 
 .hud-kv-tag {
@@ -2109,6 +2124,9 @@ img {
   .stats-grid { grid-template-columns: 1fr; }
   .local-demo-wrapper { padding: 16px; }
   .hud-stats-grid { grid-template-columns: 1fr; }
+  .screen-hud-bar { align-items: flex-start; flex-direction: column; gap: 8px; }
+  .hud-left, .hud-right { width: 100%; }
+  .hud-right { flex-wrap: wrap; }
 }
 
 /* 磁吸 */
@@ -2173,4 +2191,3 @@ img {
   .reveal-block { opacity: 1; transform: none; }
   .marquee-track { animation: none; }
 }
-

--- a/docs/landing/src/style.css
+++ b/docs/landing/src/style.css
@@ -1564,30 +1564,492 @@ img {
 .footer-right { display: flex; gap: 8px; flex-wrap: wrap; align-items: center; }
 .footer-divider { color: var(--hairline); }
 
-/* ---------- 回到顶部 ---------- */
-.back-to-top {
-  position: fixed;
-  right: 24px;
-  bottom: 24px;
-  z-index: 99;
-  width: 44px;
-  height: 44px;
-  border-radius: 50%;
-  background: var(--canvas);
-  color: var(--fg);
+
+/* ---------- STATS COUNTERS ---------- */
+.stats-counter-section {
+  padding: 32px 0 48px;
+  background: var(--bg);
+  border-bottom: 1px solid var(--hairline);
+}
+
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 24px;
+}
+
+.stat-box {
+  background: var(--surface-pearl);
   border: 1px solid var(--hairline);
+  border-radius: 16px;
+  padding: 24px 20px;
+  text-align: center;
+  transition: transform 0.2s ease, border-color 0.2s ease;
+}
+
+.stat-box:hover {
+  transform: translateY(-2px);
+  border-color: var(--color-primary);
+}
+
+.stat-val-huge {
+  font-size: 32px;
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  color: var(--color-primary);
+  font-family: var(--font-mono);
+  margin-bottom: 4px;
+}
+
+.stat-lbl {
+  font-size: 13px;
+  color: var(--fg-muted);
+  font-weight: 500;
+}
+
+/* ---------- LOCAL MODEL DEMO ---------- */
+.local-demo-section {
+  padding: 80px 0;
+}
+
+.local-demo-wrapper {
+  display: grid;
+  grid-template-columns: 360px 1fr;
+  gap: 32px;
+  margin-top: 40px;
+  background: var(--surface-tile-1);
+  border: 1px solid #333336;
+  border-radius: 20px;
+  padding: 32px;
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.4);
+}
+
+.local-demo-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.control-header {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.control-badge {
+  font-size: 11px;
+  font-weight: 700;
+  color: #38bdf8;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.control-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: #f1f5f9;
+}
+
+.model-buttons {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.model-chip-btn {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 14px;
+  background: #1e1e22;
+  border: 1px solid #2d2d34;
+  border-radius: 12px;
+  color: #94a3b8;
   cursor: pointer;
+  font-size: 12px;
+  font-family: var(--font-mono);
+  transition: all 0.2s ease;
+  text-align: left;
+}
+
+.model-chip-btn:hover {
+  background: #2a2a30;
+  color: #ffffff;
+}
+
+.model-chip-btn.active {
+  background: rgba(0, 102, 204, 0.25);
+  border-color: #0066cc;
+  color: #ffffff;
+}
+
+.chip-name {
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 200px;
+}
+
+.chip-size {
+  font-size: 11px;
+  opacity: 0.7;
+}
+
+.hardware-toggles {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 14px;
+  background: #18181c;
+  border: 1px solid #28282e;
+  border-radius: 12px;
+}
+
+.toggle-item {
   display: flex;
   align-items: center;
-  justify-content: center;
-  opacity: 0;
-  visibility: hidden;
-  transition: opacity 0.25s ease, visibility 0.25s ease, transform 0.25s ease;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.08);
+  gap: 10px;
+  font-size: 13px;
+  color: #cbd5e1;
+  cursor: pointer;
+  user-select: none;
 }
-.back-to-top.show { opacity: 1; visibility: visible; }
-.back-to-top:hover { transform: translateY(-2px); }
-.back-to-top svg { width: 18px; height: 18px; }
+
+.toggle-item input {
+  display: none;
+}
+
+.toggle-box {
+  width: 18px;
+  height: 18px;
+  border-radius: 4px;
+  border: 1.5px solid #475569;
+  position: relative;
+  transition: all 0.2s ease;
+}
+
+.toggle-item input:checked + .toggle-box {
+  background: #0066cc;
+  border-color: #0066cc;
+}
+
+.toggle-item input:checked + .toggle-box::after {
+  content: '';
+  position: absolute;
+  left: 5px;
+  top: 2px;
+  width: 5px;
+  height: 9px;
+  border: solid #ffffff;
+  border-width: 0 2px 2px 0;
+  transform: rotate(45deg);
+}
+
+.hud-stats-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 12px;
+  margin-top: 4px;
+}
+
+.hud-stat {
+  background: #141417;
+  border: 1px solid #26262c;
+  border-radius: 10px;
+  padding: 10px 12px;
+}
+
+.stat-label {
+  font-size: 10px;
+  color: #64748b;
+  font-family: var(--font-mono);
+  margin-bottom: 4px;
+}
+
+.stat-val {
+  font-size: 15px;
+  font-weight: 700;
+  color: #f8fafc;
+  font-family: var(--font-mono);
+}
+
+.stat-val.highlight {
+  color: #38bdf8;
+}
+
+.stat-bar-track {
+  height: 3px;
+  background: #27272a;
+  border-radius: 2px;
+  margin-top: 6px;
+  overflow: hidden;
+}
+
+.stat-bar-fill {
+  height: 100%;
+  background: #3b82f6;
+  transition: width 0.3s ease;
+}
+
+.stat-bar-fill.metal {
+  background: #a855f7;
+}
+
+/* Local Screen Right Panel */
+.local-demo-screen {
+  background: #0d0d11;
+  border: 1px solid #26262e;
+  border-radius: 16px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.screen-hud-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 18px;
+  background: #14141b;
+  border-bottom: 1px solid #22222a;
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+
+.hud-left {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: #e2e8f0;
+}
+
+.hud-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #10b981;
+  box-shadow: 0 0 8px rgba(16, 185, 129, 0.6);
+}
+
+.hud-speed-badge {
+  background: rgba(56, 189, 248, 0.15);
+  color: #38bdf8;
+  padding: 2px 8px;
+  border-radius: 6px;
+  font-size: 11px;
+  border: 1px solid rgba(56, 189, 248, 0.3);
+}
+
+.screen-chat-area {
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  overflow-y: auto;
+  font-size: 14px;
+}
+
+.chat-row {
+  display: flex;
+  flex-direction: column;
+  max-width: 85%;
+}
+
+.chat-row.user {
+  align-self: flex-end;
+}
+
+.chat-row.bot {
+  align-self: flex-start;
+}
+
+.chat-bubble {
+  padding: 12px 16px;
+  border-radius: 14px;
+  line-height: 1.5;
+}
+
+.chat-bubble.user {
+  background: #0066cc;
+  color: #ffffff;
+  border-bottom-right-radius: 4px;
+}
+
+.chat-bubble.bot {
+  background: #1e1e24;
+  color: #e2e8f0;
+  border: 1px solid #2d2d38;
+  border-bottom-left-radius: 4px;
+}
+
+.chat-think-box {
+  background: rgba(30, 41, 59, 0.5);
+  border: 1px dashed #334155;
+  border-radius: 10px;
+  padding: 10px 14px;
+  margin-bottom: 10px;
+  color: #94a3b8;
+  font-size: 12px;
+  font-family: var(--font-mono);
+}
+
+.think-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: #cbd5e1;
+  font-weight: 600;
+  margin-bottom: 6px;
+}
+
+.think-content {
+  line-height: 1.4;
+  opacity: 0.85;
+}
+
+/* ---------- MCP & SKILLS DEMO ---------- */
+.mcp-skills-section {
+  padding: 80px 0;
+}
+
+.mcp-demo-container {
+  margin-top: 40px;
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  gap: 24px;
+}
+
+.mcp-tabs {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.mcp-tab-btn {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 16px;
+  background: var(--canvas);
+  border: 1px solid var(--hairline);
+  border-radius: 14px;
+  text-align: left;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.mcp-tab-btn:hover {
+  border-color: var(--color-primary);
+  transform: translateX(2px);
+}
+
+.mcp-tab-btn.active {
+  background: var(--surface-pearl);
+  border-color: var(--color-primary);
+  box-shadow: 0 4px 14px rgba(0, 102, 204, 0.12);
+}
+
+.tab-type {
+  font-size: 10px;
+  font-weight: 700;
+  color: var(--color-primary);
+  font-family: var(--font-mono);
+  letter-spacing: 0.05em;
+}
+
+.tab-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--fg);
+}
+
+.mcp-display-card {
+  background: var(--canvas);
+  border: 1px solid var(--hairline);
+  border-radius: 18px;
+  padding: 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.04);
+}
+
+.mcp-card-header h3 {
+  font-size: 20px;
+  margin-top: 6px;
+  font-weight: 700;
+}
+
+.mcp-badge {
+  display: inline-block;
+  font-size: 11px;
+  font-weight: 600;
+  padding: 3px 10px;
+  background: rgba(0, 102, 204, 0.1);
+  color: var(--color-primary);
+  border-radius: 20px;
+  font-family: var(--font-mono);
+}
+
+.mcp-desc {
+  margin-top: 8px;
+  color: var(--fg-secondary);
+  line-height: 1.5;
+}
+
+.mcp-code-preview {
+  background: #0f172a;
+  border-radius: 12px;
+  overflow: hidden;
+  border: 1px solid #1e293b;
+}
+
+.code-bar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 14px;
+  background: #1e293b;
+}
+
+.code-bar .dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+}
+
+.code-bar .dot.red { background: #ef4444; }
+.code-bar .dot.yellow { background: #f59e0b; }
+.code-bar .dot.green { background: #10b981; }
+
+.code-filename {
+  margin-left: 10px;
+  font-size: 11px;
+  font-family: var(--font-mono);
+  color: #94a3b8;
+}
+
+.mcp-code-preview pre {
+  padding: 18px;
+  color: #e2e8f0;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  line-height: 1.5;
+  overflow-x: auto;
+}
+
+@media (max-width: 1024px) {
+  .stats-grid { grid-template-columns: repeat(2, 1fr); }
+  .local-demo-wrapper { grid-template-columns: 1fr; }
+  .mcp-demo-container { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 720px) {
+  .stats-grid { grid-template-columns: 1fr; }
+  .local-demo-wrapper { padding: 16px; }
+  .hud-stats-grid { grid-template-columns: 1fr; }
+}
 
 /* 磁吸 */
 .is-magnetic {
@@ -1651,3 +2113,4 @@ img {
   .reveal-block { opacity: 1; transform: none; }
   .marquee-track { animation: none; }
 }
+

--- a/docs/landing/src/style.css
+++ b/docs/landing/src/style.css
@@ -1564,6 +1564,34 @@ img {
 .footer-right { display: flex; gap: 8px; flex-wrap: wrap; align-items: center; }
 .footer-divider { color: var(--hairline); }
 
+/* ---------- 回到顶部 ---------- */
+.back-to-top {
+  position: fixed;
+  right: 24px;
+  bottom: 24px;
+  z-index: 99;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  background: var(--canvas);
+  color: var(--fg);
+  border: 1px solid var(--hairline);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.25s ease, visibility 0.25s ease, transform 0.25s ease;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.08);
+}
+.back-to-top.show { opacity: 1; visibility: visible; }
+.back-to-top:hover { transform: translateY(-2px); }
+.back-to-top:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+.back-to-top svg { width: 18px; height: 18px; }
 
 /* ---------- STATS COUNTERS ---------- */
 .stats-counter-section {
@@ -1830,6 +1858,28 @@ img {
   border-radius: 50%;
   background: #10b981;
   box-shadow: 0 0 8px rgba(16, 185, 129, 0.6);
+}
+
+.hud-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.hud-kv-tag {
+  background: rgba(148, 163, 184, 0.15);
+  color: #94a3b8;
+  padding: 2px 8px;
+  border-radius: 6px;
+  font-size: 11px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  transition: all 0.2s ease;
+}
+
+.hud-kv-tag.active {
+  background: rgba(16, 185, 129, 0.15);
+  color: #10b981;
+  border-color: rgba(16, 185, 129, 0.3);
 }
 
 .hud-speed-badge {

--- a/docs/landing/src/style.css
+++ b/docs/landing/src/style.css
@@ -1735,6 +1735,7 @@ img {
 }
 
 .toggle-item {
+  position: relative;
   display: flex;
   align-items: center;
   gap: 10px;
@@ -1745,7 +1746,11 @@ img {
 }
 
 .toggle-item input {
-  display: none;
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  pointer-events: none;
 }
 
 .toggle-box {
@@ -1772,6 +1777,11 @@ img {
   border: solid #ffffff;
   border-width: 0 2px 2px 0;
   transform: rotate(45deg);
+}
+
+.toggle-item input:focus-visible + .toggle-box {
+  outline: 2px solid #38bdf8;
+  outline-offset: 2px;
 }
 
 .hud-stats-grid {


### PR DESCRIPTION
## 改动内容

- **宣传主页更新**：新增端侧 GGUF 本地模型推理与性能 HUD 演示组件 (`LocalModelDemo`)、MCP 协议与 Agent Skills 工具体验区 (`McpSkillsDemo`) 以及项目量化数据统计栏。
- **多语言同步**：补充并全面更新中/英/日/俄/繁中 5 语种宣发文案 (`i18n.js`)。
- **磁吸光标优化**：优化 iPadOS 风格指针 (`useContextCursor.js`)，自由移动模式设为 1:1 坐标实时跟随，吸附态提升插值与变形速率，消除视觉滞后感。

## 验证

- 执行 `npm run build` 构建成功，无编译错误，静态产物正常输出。

## 截图或录屏

- 暂无

## CLA

- [x] I have read the CLA Document and I hereby sign the CLA.

## Summary by Sourcery

Update the marketing landing page to showcase on-device GGUF local models and MCP/Agent Skills tooling, and improve the magnetic cursor interaction latency.

New Features:
- Add interactive GGUF on-device local model demo and performance HUD section to the landing page.
- Add MCP protocol and Agent Skills sandbox demo section highlighting tool ecosystem capabilities.

Enhancements:
- Refresh multi-language landing copy (Simplified/Traditional Chinese, English, Japanese, Russian) to emphasize local LLM, security, and tooling features.
- Introduce stats counter bar and adjust layout/section styling to better present app scale and capabilities.
- Optimize the iPadOS-style magnetic cursor to track pointer movement with reduced visual lag and snappier hover transformations.

Documentation:
- Update landing page content across five languages to align with current product positioning around on-device LLM, MCP tools, security, and backup.